### PR TITLE
Memoize - Queue multiple calls before completion

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -610,6 +610,7 @@
 
     async.memoize = function (fn, hasher) {
         var memo = {};
+        var queues = {};
         hasher = hasher || function (x) {
             return x;
         };
@@ -620,10 +621,18 @@
             if (key in memo) {
                 callback.apply(null, memo[key]);
             }
+            else if (key in queues) {
+                queues[key].push(callback);
+            }
             else {
+                queues[key] = [callback];
                 fn.apply(null, args.concat([function () {
                     memo[key] = arguments;
-                    callback.apply(null, arguments);
+                    var q = queues[key];
+                    delete queues[key];
+                    for (var i = 0, l = q.length; i < l; i++) {
+                      q[i].apply(null, arguments);
+                    }
                 }]));
             }
         };

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -1231,6 +1231,24 @@ exports['memoize error'] = function (test) {
     test.done();
 };
 
+exports['memoize multiple calls'] = function (test) {
+    test.expect(3);
+    var fn = function (arg1, arg2, callback) {
+        test.ok(true);
+        setTimeout(function(){
+            callback(null, arg1, arg2);
+        }, 10);
+    };
+    var fn2 = async.memoize(fn);
+    fn2(1, 2, function(err, result) {
+        test.equal(result, 1, 2);
+    });
+    fn2(1, 2, function(err, result) {
+        test.equal(result, 1, 2);
+        test.done();
+    });
+};
+
 exports['memoize custom hash function'] = function (test) {
     test.expect(2);
     var testerr = new Error('test');


### PR DESCRIPTION
By queueing up multiple calls to memoize (grouped by arguments hash), we can ensure the wrapped function will only be called once.  This is especially handy when firing multiple calls in rapid succession (on a web server for instance).
