### PR TITLE
Prevent stack limit errors by using nextTick

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -126,7 +126,7 @@
                         callback();
                     }
                     else {
-                        iterate();
+                        async.nextTick(iterate);
                     }
                 }
             });


### PR DESCRIPTION
I recently ran into a problem where I was firing off deeply nested callbacks that traversed a tree structure via async.series and async.forEachSeries, this caused a stack limit error when the tree was large.

Switching from series to parallel fixed the stack problem, although I'm not entirely sure that the code actually works correctly when executed this way.

Anyway, the point is that with a simple change to async (which breaks no tests), the stack limit problem can be effectively avoided and hidden from the developer! Hooray \o/  
