### PR TITLE
async.waterfall - set callback before using it

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -386,10 +386,10 @@
     };
 
     async.waterfall = function (tasks, callback) {
+        callback = callback || function () {};
         if (!tasks.length) {
             return callback();
         }
-        callback = callback || function () {};
         var wrapIterator = function (iterator) {
             return function (err) {
                 if (err) {


### PR DESCRIPTION
if you pass an empty array and no callback an error occurs (because callback is undefined)
