### PR TITLE
Added queue.setConcurrency() method

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -614,7 +614,11 @@
             },
             running: function () {
                 return workers;
-            }
+            },
+            setConcurrency : function(n) {
+    			this.concurrency = n;
+				this.process();
+			}
         };
         return q;
     };


### PR DESCRIPTION
Added setConcurrency() method, which enables changing concurrency on the fly after tasks have been added.
This gives you the possibility to start the queue asynchronously by initializing concurrency in 0.
It would be great to have an init() method tough.
