### PR TITLE
async.command_queue function

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -686,5 +686,41 @@
         return (fn.unmemoized || fn).apply(null, arguments);
       }
     };
+    
+    //like async.parallel but tasks can be changed during execution
+    //unlike async.queue that is a data queue handled by worker function
+    async.command_queue = function(tasks, callback){
+        var workers = 0;
+        function next(err){
+          workers--;
+          if(err || tasks.length + workers == 0)
+            callback(err);
+          else
+            run();
+        }
+
+        function start_task(task){
+          async.nextTick(function(){
+              task.call(null, next);
+              });
+        }
+
+        function run(){
+          var task;
+          while(task = tasks.shift()){
+            workers++;
+            start_task(task);
+          }
+        }
+
+        function push(){
+            tasks.push(async.apply.apply(null, arguments));
+            run();
+        }
+
+        run();
+
+        return push;
+    };
 
 }());


### PR DESCRIPTION
It works like async.parallel but new task can be added during execution.
Unlike async.queue that handles the data queue.

I can add concurrency if needed, then it will be similar to the pool of parallel threads (in multithreaded world)
