### PR TITLE
Allow `async.apply()` be called with `this` and name of function property

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -534,11 +534,18 @@
         return makeCallback(0);
     };
 
-    async.apply = function (fn) {
-        var args = Array.prototype.slice.call(arguments, 1);
+    async.apply = function (fn, name) {
+        var sliceCount = 1;
+        var thisArg = null;
+        if (typeof fn !== 'function' && typeof fn.apply !== 'function') {
+            thisArg = fn;
+            fn = thisArg[name];
+            sliceCount = 2;
+        }
+        var args = Array.prototype.slice.call(arguments, sliceCount);
         return function () {
             return fn.apply(
-                null, args.concat(Array.prototype.slice.call(arguments))
+                thisArg, args.concat(Array.prototype.slice.call(arguments))
             );
         };
     };

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -951,7 +951,7 @@ exports['sortBy'] = function(test){
 };
 
 exports['apply'] = function(test){
-    test.expect(6);
+    test.expect(21);
     var fn = function(){
         test.same(Array.prototype.slice.call(arguments), [1,2,3,4])
     };
@@ -960,6 +960,30 @@ exports['apply'] = function(test){
     async.apply(fn, 1, 2)(3, 4);
     async.apply(fn, 1)(2, 3, 4);
     async.apply(fn)(1, 2, 3, 4);
+
+    var thisArg = {
+        fn: function() {
+            test.same(Array.prototype.slice.call(arguments), [1, 2, 3, 4]);
+            test.equal(this, thisArg);
+        }
+    };
+    async.apply(thisArg, 'fn', 1, 2, 3, 4)();
+    async.apply(thisArg, 'fn', 1, 2, 3)(4);
+    async.apply(thisArg, 'fn', 1, 2)(3, 4);
+    async.apply(thisArg, 'fn', 1)(2, 3, 4);
+    async.apply(thisArg, 'fn')(1, 2, 3, 4);
+
+    var objFn = {
+        apply: function() {
+            fn.apply.apply(fn, Array.prototype.slice.call(arguments));
+       }
+    };
+    async.apply(objFn, 1, 2, 3, 4)();
+    async.apply(objFn, 1, 2, 3)(4);
+    async.apply(objFn, 1, 2)(3, 4);
+    async.apply(objFn, 1)(2, 3, 4);
+    async.apply(objFn)(1, 2, 3, 4);
+
     test.equals(
         async.apply(function(name){return 'hello ' + name}, 'world')(),
         'hello world'


### PR DESCRIPTION
- When neither `fn`, nor `fn.apply` is a function, `fn` is used as this
  for `apply()`. In this case the second argument is a property name in
  `fn` specifying the method to be called
- This does not break existing users of the API, unless they are relying on `async.apply()` to fail for non  function arguments. Keeps working for people who passed objects as `fn` containing an `apply()` property to `async.apply()`
- Documentation change would follow
