### PR TITLE
Allow unspecified callback in #queue.push(task, callback)

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -594,7 +594,7 @@
             empty: null,
             drain: null,
             push: function (data, callback) {
-                q.tasks.push({data: data, callback: callback});
+                q.tasks.push({data: data, callback: typeof callback === 'function' ? callback : null});
                 if(q.saturated && q.tasks.length == concurrency) q.saturated();
                 async.nextTick(q.process);
             },


### PR DESCRIPTION
Hi Caolan,

Here is a simple pull request, that makes possible the use of async.queue.push in a .forEach loop as in:

[1,2,3].forEach( myAsyncQueue.push )

Thx,

Pierre
