### PR TITLE
The function `_indexOf` is never used

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -64,18 +64,6 @@
         return keys;
     };
 
-    var _indexOf = function (arr, item) {
-        if (arr.indexOf) {
-            return arr.indexOf(item);
-        }
-        for (var i = 0; i < arr.length; i += 1) {
-            if (arr[i] === item) {
-                return i;
-            }
-        }
-        return -1;
-    };
-
     //// exported async module functions ////
 
     //// nextTick implementation with browser-compatible fallback ////


### PR DESCRIPTION
Just a small cleanup. I removed `_indexOf`, since it is never used.
