### PR TITLE
npm 1.1.1 compatibility fix

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+deps
+dist
+test
+nodelint.cfg

--- a/package.json
+++ b/package.json
@@ -13,9 +13,16 @@
     , "url" : "http://github.com/caolan/async/raw/master/LICENSE"
     }
   ]
+, "dependencies":
+  { "uglify-js": "1.2.x"
+  }
 , "devDependencies":
-    { "uglify-js": ">0.0.0"
-    , "nodeunit": ">0.0.0"
+    { "nodeunit": ">0.0.0"
     , "nodelint": ">0.0.0"
     }
+, "scripts":
+  { "preinstall": "make clean"
+  , "install": "make build"
+  , "test": "make test"
+  }
 }


### PR DESCRIPTION
isaacs/npm#2195 describes a side effect of the fix for isaacs/npm#1872 that causes dist/async.min.js to be removed when running `npm rebuild` in applications dependent upon `async`.

This pull request addresses the issue by aligning the way async is "installed" with the behavior of npm.
