### PR TITLE
Allow nested arrays in waterfall

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -64,6 +64,26 @@
         return keys;
     };
 
+    var _isArray = function(obj) {
+        if (Array.isArray) {
+            return Array.isArray(obj);
+        }
+
+        return Object.toString.call(obj) === "[object Array]";
+    };
+
+    var _flatten = function (arr) {
+        return _reduce(arr, function(memo, value) {
+            if (_isArray(value)) {
+                return memo.concat(_flatten(value));
+            }
+
+            memo.push(value);
+
+            return memo;
+        }, []);
+    };
+
     //// exported async module functions ////
 
     //// nextTick implementation with browser-compatible fallback ////
@@ -123,21 +143,21 @@
         };
         iterate();
     };
-    
+
     async.forEachLimit = function (arr, limit, iterator, callback) {
         callback = callback || function () {};
         if (!arr.length || limit <= 0) {
-            return callback(); 
+            return callback();
         }
         var completed = 0;
         var started = 0;
         var running = 0;
-        
+
         (function replenish () {
           if (completed === arr.length) {
               return callback();
           }
-          
+
           while (running < limit && started < arr.length) {
             iterator(arr[started], function (err) {
               if (err) {
@@ -422,6 +442,7 @@
         if (!tasks.length) {
             return callback();
         }
+
         var wrapIterator = function (iterator) {
             return function (err) {
                 if (err) {
@@ -443,7 +464,7 @@
                 }
             };
         };
-        wrapIterator(async.iterator(tasks))();
+        wrapIterator(async.iterator(_flatten(tasks)))();
     };
 
     async.parallel = function (tasks, callback) {

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -257,6 +257,7 @@ exports['waterfall error'] = function(test){
 
 exports['waterfall multiple callback calls'] = function(test){
     var call_order = [];
+    var finalCalls = 0;
     var arr = [
         function(callback){
             call_order.push(1);
@@ -274,16 +275,38 @@ exports['waterfall multiple callback calls'] = function(test){
         },
         function(arg4){
             call_order.push(4);
-            arr[3] = function(){
-                call_order.push(4);
+            finalCalls++;
+            if (finalCalls === 2) {
                 test.same(call_order, [1,2,2,3,3,4,4]);
                 test.done();
-            };
+            }
         }
     ];
     async.waterfall(arr);
 };
 
+exports['waterfall nested array'] = function(test){
+    test.expect(3);
+    async.waterfall([
+        function(callback){
+            callback(null);
+        }, [
+            function(callback){
+                test.ok(true, 'inner function 1 was called');
+                callback();
+            },
+            function(callback){
+                test.ok(true, 'inner function 2 was called');
+                callback(null, 1);
+            }
+        ],
+        function(a, callback) {
+            test.equal(a, 1, 'args were preserved');
+            test.done();
+            callback();
+        }
+    ]);
+};
 
 exports['parallel'] = function(test){
     var call_order = [];
@@ -618,7 +641,7 @@ exports['forEachLimit error'] = function(test){
     test.expect(2);
     var arr = [0,1,2,3,4,5,6,7,8,9];
     var call_order = [];
-    
+
     async.forEachLimit(arr, 3, function(x, callback){
         call_order.push(x);
         if (x === 2) {


### PR DESCRIPTION
Hey there!

This is a pretty simple enhancement to waterfall, which flattens the tasks array prior to running the tasks.  In practice, this means you can now pass sub-arrays of tasks in.  This is handy because it allows you to create reusable tasks that can be included in waterfall workflows, where tasks can be waterfalls themselves.

For example:

```
function foo(done) {
  console.log('foo');
}

function bar(done) {
  console.log('bar');
}

function baz(done) {
  console.log('baz');
}

var foobar = [foo, bar];

async.waterfall([
  foobar,
  baz
]);

// logs foo, bar, baz
```

What do you think?

(this is inspired by Connect middleware's similar behavior)
