### PR TITLE
Adding onEach, support for EventEmitters 

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ So far its been tested in IE6, IE7, IE8, FF3.6 and Chrome 5. Usage:
 * [until](#until)
 * [waterfall](#waterfall)
 * [queue](#queue)
+* [onEach](#onEach)
 * [auto](#auto)
 * [iterator](#iterator)
 * [apply](#apply)
@@ -740,6 +741,48 @@ __Example__
         console.log('finished processing bar');
     });
 
+
+---------------------------------------
+
+<a name="onEach" />
+### onEach(eventemitter, concurrency, process_event_name, process_func, end_event_name, all_done
+
+Executes process_func on every process_event_name event that the eventemitter emits.
+Process_func is called with every argument it would usually be called with an extra callback
+argument.
+After the end event is emitted and all outstanding process_funcs are done, the final all_done
+callback will be called.
+
+__Arguments__
+
+* eventemitter - An EventEmitter that has an 'on' method to register listeners taking an event name
+  and a callback.
+* concurrency - An integer for determining how many worker functions should be
+  run in parallel.
+* process_event_name - The name of the event that we should register the working function for
+* process_func(arguments..., callback) - The function that does the work. It accepts the
+  same arguments as the original eventlistener, with an added callback for completion.
+* end_event_name - The name of the event that signals the last processing event has been emitted.
+* all_done() - Callback when the end event has been emitted and all outstanding processes have
+  completed
+
+__Example__
+
+    var http = require('http');
+
+    http.createServer(function (req, res) {
+
+      var saveChunk = function(chunk, callback) {
+        saveToDB(chunk, callback);
+      }
+
+      async.onEach(req, 2, 'data', saveChunk, 'end', function() {
+        console.log 'All done';
+      });
+
+    }).listen(8080);
+
+    console.log("Server started on http://localhost:8080/");
 
 ---------------------------------------
 

--- a/lib/async.js
+++ b/lib/async.js
@@ -625,6 +625,29 @@
         return q;
     };
 
+    async.onEach = function(eventemitter, concurrency, process_event_name, process_func, end_event_name, all_done) {
+        callProcessFunc = function(json, callback) {
+            var args = JSON.parse(json);
+            process_func.apply(null, Array.prototype.slice.call(args).concat([callback]));
+        };
+
+        var queue = async.queue(callProcessFunc, concurrency);
+        var events_done = false;
+
+        queue.drain = function() {
+            if (events_done) return all_done();
+        };
+
+        eventemitter.on(process_event_name, function() {
+            var args = 1 <= arguments.length ? Array.prototype.slice.call(arguments, 0) : [];
+            queue.push(JSON.stringify(args));
+        });
+
+        eventemitter.on(end_event_name, function() {
+            events_done = true;
+        });
+    };
+
     var _console_fn = function (name) {
         return function (fn) {
             var args = Array.prototype.slice.call(arguments, 1);

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -1602,3 +1602,58 @@ exports['queue events'] = function(test) {
     q.push('poo', function () {calls.push('poo cb');});
     q.push('moo', function () {calls.push('moo cb');});
 };
+
+exports['onEach'] = function(test) {
+    var nextEvent = 0;
+    var texts = ['Zero', 'One', 'Two', 'Three'];
+
+    var eventemitter = {
+        processListener: null,
+        endListener: null,
+        on: function (event, fn) {
+            if (event === 'process') {
+                processListener = fn;
+            }
+            else if (event === 'end') {
+                endListener = fn;
+            }
+            else {
+                test.ok(false, 'Registering wrong listener');
+            }
+        },
+        start: function () {
+            setTimeout(function() {
+                processListener(0, 'Zero');
+            }, 40);
+            setTimeout(function() {
+                processListener(1, 'One');
+            }, 80);
+            setTimeout(function() {
+                processListener(2, 'Two');
+            }, 120);
+            setTimeout(function() {
+                processListener(3, 'Three');
+            }, 160);
+            setTimeout(function() {
+                endListener();
+            }, 200)
+        }
+    };
+
+    var processFunc = function(number, text, callback) {
+        test.equal(number, nextEvent);
+        test.equal(text, texts[number]);
+        nextEvent++;
+        setTimeout(function() {
+            callback();
+        }, number*20);
+    };
+
+    var done = function() {
+        test.ok(nextEvent, 4);
+        test.done();
+    };
+
+    async.onEach(eventemitter, 1, 'process', processFunc, 'end', done);
+    eventemitter.start();
+}


### PR DESCRIPTION
I have added a method onEach that takes a couple of parameters to ease working with events.
I have to do a lot of parsing of cvs and xml files and most streaming libraries use events for this.

Internally is registers some events on the emitters and then uses a queue internally to keep track of work.
I have added some tests and some documentation.

Normally I do my programming in Coffeescript in Node, so I might not be aware of some Javascript conventions. This is also my first github pull request, so the same goes for that.

As for my code, there are 2 things I do not like.
- I think like the number of arguments, but I can't think of a good way to make it less
- Internally I use JSON.stringify and JSON.parse, because whenqueue.push sees an Array it assumes there are multiple tasks. Also here I can't find a good way to work around this.
