### PR TITLE
Fixed a bug where queue processing could cause a stack overflow.

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -611,7 +611,7 @@
                             task.callback.apply(task, arguments);
                         }
                         if(q.drain && q.tasks.length + workers == 0) q.drain();
-                        q.process();
+                        async.nextTick(q.process);
                     });
                 }
             },


### PR DESCRIPTION
Hi there,

I fixed a bug in the async queue processing. The recursion in the #process method has the potential to cause a stack overflow if the queue is large. Using #nextTick resolves this issue.

Thanks for the great library.
