### PR TITLE
"completed" counter issue with async.forEach

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -90,7 +90,7 @@
                 }
                 else {
                     completed += 1;
-                    if (completed === arr.length) {
+                    if (completed >= arr.length) {
                         callback();
                     }
                 }
@@ -112,7 +112,7 @@
                 }
                 else {
                     completed += 1;
-                    if (completed === arr.length) {
+                    if (completed >= arr.length) {
                         callback();
                     }
                     else {


### PR DESCRIPTION
An issue appears in Chrome (but not node) where the completed counter goes above the array length on a forEach. Somehow the === comparison between completed and arr.length is failing.

Not sure the exact cause and I had trouble coming up with a test to reproduce, but thought I'd throw it out there for your consideration.
