### PR TITLE
Add rate limiting to queues

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -726,6 +726,7 @@
         // internal state
         this.$rateLimitTimeout = 0;
         this.$rateLimitBusy = false;
+        this.$rateLimitInterval = null;
         
         // wrapper around push that pushes to our own queue instead of tasks
         this.push = function (data, callback) {
@@ -737,23 +738,19 @@
             });
             
             toProcess += data.length;
-            
-            if (!this.$rateLimitBusy) {
-                this.$processNextRateLimitedImpl();
-            }
         };
         
         // kick off the rate limiter
         this.rateLimit = function (timeout) {
             this.$rateLimitTimeout = timeout || 1000;
-            this.$processNextRateLimitedImpl();
+            this.$processNextRateLimited();
         };
         
         // invoke the rate limit implementation with a timeout
         this.$processNextRateLimited = function () {
             var self = this;
             
-            setTimeout(function () {
+            self.$rateLimitInterval = setInterval(function () {
                 self.$processNextRateLimitedImpl();
             }, self.$rateLimitTimeout);
         };
@@ -791,14 +788,13 @@
                 if (toProcess === 0) {
                     self.$rateLimitBusy = false;
                     
+                    clearInterval(self.$rateLimitInterval);
+                    
                     if (typeof _drain === "function") {
                         _drain();
                     }
                 }
             });
-            
-            // call the next item, we don't have to care about concurrency here
-            this.$processNextRateLimited();
         };
         
         var $emptyDrain = function () {};


### PR DESCRIPTION
@caolan, Often I find myself dealing with rate limited API's. This pull request adds rate limiting to async's queues so you don't have to deal with that yourself.

Usage:

``` javascript
var q = async.queue(function (item, next) {
    console.log(item);
    next();
}, 2).rateLimit(1000);

q.drain = function () {
    console.log("We're all done");
};

q.push([ 1,2,3,4,5,6,7,8,9,10 ]);
```

Just like a normal queue, only you can chain a `rateLimit` command to the queue (or invoke it via `q.rateLimit()` later on). The argument is the number of ms. minimally required to wait between consecutive requests. Ergo, for a 100/min. rate limit, use 60000/100. The feature has been built by adding a mixin to the queue when the `rateLimit` function is invoked.
