### PR TITLE
Add times and timesSeries functions for asynchronously executing a function n times

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ So far its been tested in IE6, IE7, IE8, FF3.6 and Chrome 5. Usage:
 * [iterator](#iterator)
 * [apply](#apply)
 * [nextTick](#nextTick)
+* [times](#times)
+* [timesSeries](#timesSeries)
 
 ### Utils
 
@@ -906,6 +908,40 @@ __Example__
         // call_order now equals ['one','two]
     });
     call_order.push('one')
+
+<a name="times" />
+### times(n, callback)
+
+Calls the callback n times and accumulates results in the same manner
+you would use with async.map.
+
+__Arguments__
+
+* n - The number of times to run the function.
+* callback - The function to call n times.
+
+__Example__
+    // Pretend this is some complicated async factory
+    var createUser = function(id, callback) {
+      callback(null, {
+        id: 'user' + id
+      })
+    }
+    // generate 5 users
+    async.times(5, function(n, next){
+        createUser(n, function(err, user) {
+          next(err, user)
+        })
+    }, function(err, users) {
+      // we should now have 5 users
+    });
+
+<a name="timesSeries" />
+### timesSeries(n, callback)
+
+The same as times only the iterator is applied to each item in the array in
+series. The next iterator is only called once the current one has completed
+processing. The results array will be in the same order as the original.
 
 
 ## Utils

--- a/lib/async.js
+++ b/lib/async.js
@@ -687,4 +687,19 @@
       }
     };
 
+    async.times = function(count, iterator, callback) {
+      var counter = []
+      for (var i = 0; i < count; i++) {
+        counter.push(i)
+      }
+      return async.map(counter, iterator, callback)
+    }
+    async.timesSeries = function(count, iterator, callback) {
+      var counter = []
+      for (var i = 0; i < count; i++) {
+        counter.push(i)
+      }
+      return async.mapSeries(counter, iterator, callback)
+    }
+
 }());

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -1028,6 +1028,76 @@ var console_fn_tests = function(name){
 
 };
 
+
+
+exports['times'] = function(test) {
+  var indices = []
+  async.times(5, function(n, next) {
+    next(null, n)
+  }, function(err, results) {
+    test.same(results, [0,1,2,3,4])
+    test.done()
+  })
+}
+
+exports['times'] = function(test){
+    var args = [];
+    async.times(3, function(n, callback){
+        setTimeout(function(){
+            args.push(n);
+            callback();
+        }, n * 25);
+    }, function(err){
+        test.same(args, [0,1,2]);
+        test.done();
+    });
+};
+
+exports['times 0'] = function(test){
+    test.expect(1);
+    async.times(0, function(n, callback){
+        test.ok(false, 'iterator should not be called');
+        callback();
+    }, function(err){
+        test.ok(true, 'should call callback');
+    });
+    setTimeout(test.done, 25);
+};
+
+exports['times error'] = function(test){
+    test.expect(1);
+    async.times(3, function(n, callback){
+        callback('error');
+    }, function(err){
+        test.equals(err, 'error');
+    });
+    setTimeout(test.done, 50);
+};
+
+exports['timesSeries'] = function(test){
+    var call_order = [];
+    async.timesSeries(5, function(n, callback){
+        setTimeout(function(){
+            call_order.push(n);
+            callback(null, n);
+        }, 100 - n * 10);
+    }, function(err, results){
+        test.same(call_order, [0,1,2,3,4]);
+        test.same(results, [0,1,2,3,4]);
+        test.done();
+    });
+};
+
+exports['timesSeries error'] = function(test){
+    test.expect(1);
+    async.timesSeries(5, function(n, callback){
+        callback('error');
+    }, function(err, results){
+        test.equals(err, 'error');
+    });
+    setTimeout(test.done, 50);
+};
+
 console_fn_tests('log');
 console_fn_tests('dir');
 /*console_fn_tests('info');
@@ -1575,3 +1645,4 @@ exports['queue events'] = function(test) {
     q.push('poo', function () {calls.push('poo cb');});
     q.push('moo', function () {calls.push('moo cb');});
 };
+


### PR DESCRIPTION
I often want to run some function multiple times (e.g. within a test setup, run this function to create n users) so I often use this pattern. Thought it might be useful to add to the async lib itself since it's a regular problem I have.
