### PR TITLE
`waterfall` now passes all arguments to callback even if there was an error.

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -425,7 +425,7 @@
         var wrapIterator = function (iterator) {
             return function (err) {
                 if (err) {
-                    callback(err);
+                    callback.apply(null, arguments);
                     callback = function () {};
                 }
                 else {


### PR DESCRIPTION
The fact that `waterfall` doesn't pass all arguments in case of an error is bad because one could be triggering errors on purpose while still wanting to maintain certain flow of data.
