### PR TITLE
Add a scripts.test to package.json to aid in kicking off nodeunit.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,4 +18,6 @@
   , "uglify-js": "1.2.x"
   , "nodelint": ">0.0.0"
   }
+, "scripts":
+  { "test": "nodeunit test/test-async.js" }
 }


### PR DESCRIPTION
Makes `npm test` work.

Alternatively, `./node_modules/nodeunit/bin/nodeunit test/test-async.js` may be an option: I have that alternative implementation in another branch, rektide@207164671c8bb1e73d1ecd261c3c6e6d . Not sure whether you'd prefer it over this here rektide@c6095ffc9b43d71e42ef96a77fb2ff2547c0af6a .

Thanks.
