### PR TITLE
An array which grows never completed a forEach

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -76,13 +76,19 @@
         async.nextTick = process.nextTick;
     }
 
-    async.forEach = function (arr, iterator, callback) {
+    async.forEach = function (arr, iterator, callback, skip) {
         callback = callback || function () {};
+        skip = skip || 0;
         if (!arr.length) {
             return callback();
         }
-        var completed = 0;
+        var completed = skip;
+        var initialLength = arr.length;
         _forEach(arr, function (x) {
+            if (skip > 0) {
+                --skip;
+                return;
+            }
             iterator(x, function (err) {
                 if (err) {
                     callback(err);
@@ -90,8 +96,13 @@
                 }
                 else {
                     completed += 1;
-                    if (completed === arr.length) {
-                        callback(null);
+                    if (completed === initialLength) {
+                        if (arr.length <= initialLength) {
+                            callback(null);
+                        }
+                        else {
+                            async.forEach(arr, iterator, callback, completed);
+                        }
                     }
                 }
             });

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -528,6 +528,21 @@ exports['forEach no callback'] = function(test){
     async.forEach([1], forEachNoCallbackIterator.bind(this, test));
 };
 
+exports['forEach with growing array'] = function(test){
+    var arr= [2,3];
+    var iterations = 0;
+    async.forEach(arr, function(x, callback){
+        if (iterations++ == 0) {
+            arr.push(4);
+        }
+        callback();
+    }, function(){
+        test.same(arr, [2,3,4]);
+        test.same(iterations, 3);
+        test.done();
+    })
+};
+
 exports['forEachSeries'] = function(test){
     var args = [];
     async.forEachSeries([1,3,2], forEachIterator.bind(this, args), function(err){


### PR DESCRIPTION
Patch and implementation to allow async.forEach to complete even if the array grows in size.

There is an alternative implementation rektide@3eda64242c5557ce2f4ee9809a0f7a8fe9af4473 that avoids this somewhat-hackish recursion (and the cost of building & storing additional state): it does, however, not make use of _forEach, & I was not sure what costs are associated with not using native Array.forEach when it is available.

Either that implementation, or this rektide@76db4aff3daa22e8149c05db793ad05aa9e01d50 implementation, both resolve the issue, which is demonstrated in the test.
