### PR TITLE
Adding forEachOf to Iterate Objects

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -57,6 +57,14 @@
         return memo;
     };
 
+    var _forEachOf = function (object, iterator) {
+        for (key in object) {
+            if (object.hasOwnProperty(key)) {
+                iterator(object[key], key);
+            }
+        }
+    };
+
     var _keys = function (obj) {
         if (Object.keys) {
             return Object.keys(obj);
@@ -108,6 +116,27 @@
                     }
                 }
             }));
+        });
+    };
+
+    async.forEachOf = function (object, iterator, callback) {
+        callback = callback || function () {};
+        var completed = 0, size = _keys(object).length, key;
+        if (!size) {
+            return callback();
+        }
+        _forEachOf(object, function (value, key) {
+            iterator(object[key], key, function (err) {
+                if (err) {
+                    callback(err);
+                    callback = function () {};
+                } else {
+                    completed += 1;
+                    if (completed === size) {
+                        callback(null);
+                    }
+                }
+            });
         });
     };
 

--- a/lib/async.js
+++ b/lib/async.js
@@ -121,7 +121,8 @@
 
     async.forEachOf = function (object, iterator, callback) {
         callback = callback || function () {};
-        var completed = 0, size = _keys(object).length, key;
+        var size = object.length || _keys(object).length;
+        var completed = 0
         if (!size) {
             return callback();
         }
@@ -173,6 +174,42 @@
         iterate();
     };
 
+    async.forEachOfSeries = function (obj, iterator, callback) {
+        callback = callback || function () {};
+        var keys = _keys(obj);
+        var size = keys.length;
+        if (!size) {
+            return callback();
+        }
+        var completed = 0;
+        var iterate = function () {
+            var sync = true;
+            var key = keys[completed];
+            iterator(obj[key], key, function (err) {
+                if (err) {
+                    callback(err);
+                    callback = function () {};
+                }
+                else {
+                    completed += 1;
+                    if (completed >= size) {
+                        callback(null);
+                    }
+                    else {
+                        if (sync) {
+                            async.nextTick(iterate);
+                        }
+                        else {
+                            iterate();
+                        }
+                    }
+                }
+            });
+            sync = false;
+        };
+        iterate();
+    };
+
     async.forEachLimit = function (arr, limit, iterator, callback) {
         var fn = _forEachLimit(limit);
         fn.apply(null, [arr, iterator, callback]);
@@ -206,6 +243,55 @@
                             completed += 1;
                             running -= 1;
                             if (completed >= arr.length) {
+                                callback();
+                            }
+                            else {
+                                replenish();
+                            }
+                        }
+                    });
+                }
+            })();
+        };
+    };
+
+
+    async.forEachOfLimit = function (obj, limit, iterator, callback) {
+        var fn = obj.constructor === Array ? _forEachOfLimit(limit) : _forEachOfLimit(limit);
+        fn.apply(null, [obj, iterator, callback]);
+    };
+
+    var _forEachOfLimit = function (limit) {
+
+        return function (obj, iterator, callback) {
+            callback = callback || function () {};
+            var keys = _keys(obj);
+            var size = keys.length;
+            if (!size || limit <= 0) {
+                return callback();
+            }
+            var completed = 0;
+            var started = 0;
+            var running = 0;
+
+            (function replenish () {
+                if (completed >= size) {
+                    return callback();
+                }
+
+                while (running < limit && started < size) {
+                    started += 1;
+                    running += 1;
+                    var key = keys[started - 1];
+                    iterator(obj[key], key, function (err) {
+                        if (err) {
+                            callback(err);
+                            callback = function () {};
+                        }
+                        else {
+                            completed += 1;
+                            running -= 1;
+                            if (completed >= size) {
                                 callback();
                             }
                             else {

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -17,6 +17,13 @@ function forEachIterator(args, x, callback) {
     }, x*25);
 }
 
+function forEachOfIterator(args, x, key, callback) {
+    setTimeout(function(){
+        args.push(key, x);
+        callback();
+    }, x*25);
+}
+
 function mapIterator(call_order, x, callback) {
     setTimeout(function(){
         call_order.push(x);
@@ -39,6 +46,13 @@ function detectIterator(call_order, x, callback) {
 
 function forEachNoCallbackIterator(test, x, callback) {
     test.equal(x, 1);
+    callback();
+    test.done();
+}
+
+function forEachOfNoCallbackIterator(test, x, key, callback) {
+    test.equal(x, 1);
+    test.equal(key, "a");
     callback();
     test.done();
 }
@@ -650,6 +664,39 @@ exports['forEach error'] = function(test){
 
 exports['forEach no callback'] = function(test){
     async.forEach([1], forEachNoCallbackIterator.bind(this, test));
+};
+
+exports['forEachOf'] = function(test){
+    var args = [];
+    async.forEachOf({ a: 1, b: 2 }, forEachOfIterator.bind(this, args), function(err){
+        test.same(args, ["a", 1, "b", 2]);
+        test.done();
+    });
+};
+
+exports['forEachOf empty object'] = function(test){
+    test.expect(1);
+    async.forEachOf({}, function(value, key, callback){
+        test.ok(false, 'iterator should not be called');
+        callback();
+    }, function(err) {
+        test.ok(true, 'should call callback');
+    });
+    setTimeout(test.done, 25);
+};
+
+exports['forEachOf error'] = function(test){
+    test.expect(1);
+    async.forEachOf({ a: 1, b: 2 }, function(value, key, callback) {
+        callback('error');
+    }, function(err){
+        test.equals(err, 'error');
+    });
+    setTimeout(test.done, 50);
+};
+
+exports['forEachOf no callback'] = function(test){
+    async.forEachOf({ a: 1 }, forEachOfNoCallbackIterator.bind(this, test));
 };
 
 exports['forEachSeries'] = function(test){


### PR DESCRIPTION
So, I needed the ability to iterate objects (and get the `key` passed into the iterator) and noticed it was not done because it would break compatibility with the Node.js standard libs. I am proposing this "convention" of adding the `Of` suffix on iterators that deal with objects. (instead of arrays)

If this entire concept is rejected outright, then I'll stop here. However, if this seems like a good idea/convention I can finish up adding the same concept to the other various collection iterators.

Usage:

    async.forEachOf({ a: 1, b: 2 }, function (value, key, callback) {
        // value = 1, 2
        // key   = a, b
    }, function (err) {
        // complete
    });