### PR TITLE
async.waterfall pass arguments to end

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -425,7 +425,7 @@
         var wrapIterator = function (iterator) {
             return function (err) {
                 if (err) {
-                    callback(err);
+                    callback.apply(null, arguments);
                     callback = function () {};
                 }
                 else {


### PR DESCRIPTION
async.waterfall pass arguments to end if some task finished with error
