### PR TITLE
Replace constructor === Array checks with safer Array.isArray

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -448,7 +448,7 @@
 
     async.parallel = function (tasks, callback) {
         callback = callback || function () {};
-        if (tasks.constructor === Array) {
+        if (Array.isArray(tasks)) {
             async.map(tasks, function (fn, callback) {
                 if (fn) {
                     fn(function (err) {
@@ -480,7 +480,7 @@
 
     async.series = function (tasks, callback) {
         callback = callback || function () {};
-        if (tasks.constructor === Array) {
+        if (Array.isArray(tasks)) {
             async.mapSeries(tasks, function (fn, callback) {
                 if (fn) {
                     fn(function (err) {


### PR DESCRIPTION
MDN Object constructor reference page ( https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Object/constructor ) states that constructor property can be changed and it is not always safe to believe in constructor function.

I found an issue when using the latest version of async with the latest version of sandboxed-module ( https://github.com/felixge/node-sandboxed-module ) where async.parallel thinks that tasks variable is not an array even though it is actually an array. This is caused by "tasks.constructor === Array" returns false, while Array.isArray(tasks) returns true.
This is very likely to be caused by sandboxed-module issue 13 ( https://github.com/felixge/node-sandboxed-module/issues/13 ) which changes the value of constructor property, and is still an open issue.

Granted that this is not an async bug, but it would be better if async doesn't rely on constructor property which can be modified by other modules, and uses Array.isArray instead.
