### PR TITLE
Support for domains.

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -78,6 +78,7 @@
 
     async.forEach = function (arr, iterator, callback) {
         callback = callback || function () {};
+        if (process.domain) callback = process.domain.bind(callback);
         if (!arr.length) {
             return callback();
         }
@@ -100,6 +101,7 @@
 
     async.forEachSeries = function (arr, iterator, callback) {
         callback = callback || function () {};
+        if (process.domain) callback = process.domain.bind(callback);
         if (!arr.length) {
             return callback();
         }
@@ -126,6 +128,7 @@
 
     async.forEachLimit = function (arr, limit, iterator, callback) {
         callback = callback || function () {};
+        if (process.domain) callback = process.domain.bind(callback);
         if (!arr.length || limit <= 0) {
             return callback();
         }
@@ -177,6 +180,7 @@
 
 
     var _asyncMap = function (eachfn, arr, iterator, callback) {
+        if (process.domain) callback = process.domain.bind(callback);
         var results = [];
         arr = _map(arr, function (x, i) {
             return {index: i, value: x};
@@ -197,6 +201,7 @@
     // reduce only has a series version, as doing reduce in parallel won't
     // work in many situations.
     async.reduce = function (arr, memo, iterator, callback) {
+        if (process.domain) callback = process.domain.bind(callback);
         async.forEachSeries(arr, function (x, callback) {
             iterator(memo, x, function (err, v) {
                 memo = v;
@@ -212,6 +217,7 @@
     async.foldl = async.reduce;
 
     async.reduceRight = function (arr, memo, iterator, callback) {
+        if (process.domain) callback = process.domain.bind(callback);
         var reversed = _map(arr, function (x) {
             return x;
         }).reverse();
@@ -221,6 +227,7 @@
     async.foldr = async.reduceRight;
 
     var _filter = function (eachfn, arr, iterator, callback) {
+        if (process.domain) callback = process.domain.bind(callback);
         var results = [];
         arr = _map(arr, function (x, i) {
             return {index: i, value: x};
@@ -247,6 +254,7 @@
     async.selectSeries = async.filterSeries;
 
     var _reject = function (eachfn, arr, iterator, callback) {
+        if (process.domain) callback = process.domain.bind(callback);
         var results = [];
         arr = _map(arr, function (x, i) {
             return {index: i, value: x};
@@ -270,6 +278,7 @@
     async.rejectSeries = doSeries(_reject);
 
     var _detect = function (eachfn, arr, iterator, main_callback) {
+        if (process.domain) main_callback = process.domain.bind(main_callback);
         eachfn(arr, function (x, callback) {
             iterator(x, function (result) {
                 if (result) {
@@ -288,6 +297,7 @@
     async.detectSeries = doSeries(_detect);
 
     async.some = function (arr, iterator, main_callback) {
+        if (process.domain) main_callback = process.domain.bind(main_callback);
         async.forEach(arr, function (x, callback) {
             iterator(x, function (v) {
                 if (v) {
@@ -304,6 +314,7 @@
     async.any = async.some;
 
     async.every = function (arr, iterator, main_callback) {
+        if (process.domain) main_callback = process.domain.bind(main_callback);
         async.forEach(arr, function (x, callback) {
             iterator(x, function (v) {
                 if (!v) {
@@ -320,6 +331,7 @@
     async.all = async.every;
 
     async.sortBy = function (arr, iterator, callback) {
+        if (process.domain) callback = process.domain.bind(callback);
         async.map(arr, function (x, callback) {
             iterator(x, function (err, criteria) {
                 if (err) {
@@ -347,6 +359,7 @@
 
     async.auto = function (tasks, callback) {
         callback = callback || function () {};
+        if (process.domain) callback = process.domain.bind(callback);
         var keys = _keys(tasks);
         if (!keys.length) {
             return callback(null);
@@ -419,6 +432,7 @@
 
     async.waterfall = function (tasks, callback) {
         callback = callback || function () {};
+        if (process.domain) callback = process.domain.bind(callback);
         if (!tasks.length) {
             return callback();
         }
@@ -448,6 +462,7 @@
 
     async.parallel = function (tasks, callback) {
         callback = callback || function () {};
+        if (process.domain) callback = process.domain.bind(callback);
         if (tasks.constructor === Array) {
             async.map(tasks, function (fn, callback) {
                 if (fn) {
@@ -480,6 +495,7 @@
 
     async.series = function (tasks, callback) {
         callback = callback || function () {};
+        if (process.domain) callback = process.domain.bind(callback);
         if (tasks.constructor === Array) {
             async.mapSeries(tasks, function (fn, callback) {
                 if (fn) {
@@ -537,6 +553,7 @@
 
     var _concat = function (eachfn, arr, fn, callback) {
         var r = [];
+        if (process.domain) callback = process.domain.bind(callback);
         eachfn(arr, function (x, cb) {
             fn(x, function (err, y) {
                 r = r.concat(y || []);
@@ -550,6 +567,7 @@
     async.concatSeries = doSeries(_concat);
 
     async.whilst = function (test, iterator, callback) {
+        if (process.domain) callback = process.domain.bind(callback);
         if (test()) {
             iterator(function (err) {
                 if (err) {
@@ -564,6 +582,7 @@
     };
 
     async.until = function (test, iterator, callback) {
+        if (process.domain) callback = process.domain.bind(callback);
         if (!test()) {
             iterator(function (err) {
                 if (err) {

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -1618,3 +1618,25 @@ exports['queue events'] = function(test) {
     q.push('poo', function () {calls.push('poo cb');});
     q.push('moo', function () {calls.push('moo cb');});
 };
+
+// test domains
+
+var d = require('domain').create()
+d.on('error', function (err) {
+  console.log('domain error:', err.message)
+  d.errors += 1
+})
+d.errors = 0
+
+pn = function (cb) {process.nextTick(function () {cb()})}
+
+d.run(function () {
+  async.forEach([1,2], function (i, cb) {pn(cb)}, function (err) {
+    throw new Error('test async')
+  })
+})
+
+process.nextTick(function () {
+  if (d.errors !== 1) throw new Error('did not pass all domain errors')
+})
+


### PR DESCRIPTION
This patch adds support for domains to async. The test addition is purely illustrative, i have no idea how to write or run tests the way you've got em and running `npm test` appears to do nothing.

The style of support:

``` javascript
if (process.domain) callback = process.domain.bind(callback)
```

Is something we discussed and established at NodeConf SummerCamp. The basic premise is that whoever owns an upper level transaction (like a web framework handling an HTTP request) will create a domain and wrap the handlers it fires for that transaction. The developer writing handlers has no idea there is a domain, and it's up to API authors (async, request, node-redis) to make sure they attach to the domain when it is active. In the case of request, it's all in an EventEmitter so it's automatically added, but for node-redis and async and other pure callback based APIs there will need to be code like this that binds the incoming callback to the domain so that any errors thrown in the handler get picked up by the transaction holder's domain.

I hope that makes sense :)
