### PR TITLE
Fix a couple minor errors in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ async.series([
     function(callback){
         // do some more stuff ...
         callback(null, 'two');
-    },
+    }
 ],
 // optional callback
 function(err, results){
@@ -556,7 +556,7 @@ async.series({
         setTimeout(function(){
             callback(null, 2);
         }, 100);
-    },
+    }
 },
 function(err, results) {
     // results is now equal to: {one: 1, two: 2}
@@ -601,7 +601,7 @@ async.parallel([
         setTimeout(function(){
             callback(null, 'two');
         }, 100);
-    },
+    }
 ],
 // optional callback
 function(err, results){
@@ -621,7 +621,7 @@ async.parallel({
         setTimeout(function(){
             callback(null, 2);
         }, 100);
-    },
+    }
 },
 function(err, results) {
     // results is now equals to: {one: 1, two: 2}
@@ -925,7 +925,7 @@ async.parallel([
     },
     function(callback){
         fs.writeFile('testfile2', 'test2', callback);
-    },
+    }
 ]);
 ```
 


### PR DESCRIPTION
Most of the examples of async.parallel correctly show the callback as taking (err, results), but one of them just shows (results). This would not work well if somebody followed it as an example.

Also, several of the examples have trailing commas in their arrays. I know this will make IE angry, and possibly other JS engines.
