### PR TITLE
Adding an optional context arg to memoize.

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -863,9 +863,10 @@
     async.warn = _console_fn('warn');
     async.error = _console_fn('error');*/
 
-    async.memoize = function (fn, hasher) {
+    async.memoize = function (fn, hasher, context) {
         var memo = {};
         var queues = {};
+        context = context || null
         hasher = hasher || function (x) {
             return x;
         };
@@ -881,12 +882,12 @@
             }
             else {
                 queues[key] = [callback];
-                fn.apply(null, args.concat([function () {
+                fn.apply(context, args.concat([function () {
                     memo[key] = arguments;
                     var q = queues[key];
                     delete queues[key];
                     for (var i = 0, l = q.length; i < l; i++) {
-                      q[i].apply(null, arguments);
+                      q[i].apply(context, arguments);
                     }
                 }]));
             }


### PR DESCRIPTION
Do you think something like this would be a good idea?

Adding a context option to memoize so that methods of an object can preserve `this`. For example:

``` javascript
var obj = {
  bar: 'value',
  foo: functions (arg, callback) {
    callback(this.bar + '!');
  }
};

obj.foo = async.memoize(obj.foo, null, obj);
```
