### PR TITLE
Made callback to map optional

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -221,10 +221,12 @@
         eachfn(arr, function (x, callback) {
             iterator(x.value, function (err, v) {
                 results[x.index] = v;
-                callback(err);
+                if (callback)
+                    callback(err);
             });
         }, function (err) {
-            callback(err, results);
+            if (callback)
+                callback(err, results);
         });
     };
     async.map = doParallel(_asyncMap);

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -987,6 +987,20 @@ exports['map error'] = function(test){
     setTimeout(test.done, 50);
 };
 
+exports['map without callback'] = function(test){
+    var a = []
+    async.series([function(callback){
+        async.map([1,2,3], function(x){
+            a.push(x);
+        });
+        callback();
+    },
+    function(callback){
+        test.same(a, [1,2,3]);
+	test.done();
+    }]);
+};
+
 exports['mapSeries'] = function(test){
     var call_order = [];
     async.mapSeries([1,3,2], mapIterator.bind(this, call_order), function(err, results){


### PR DESCRIPTION
Execution of the callback in map (_asyncMap) is now only done if
there is a callback present.

I added a small test that relies on series() to check the side
effects of the map() call.

This is an attempt to fix issue #145
