### PR TITLE
optimize usage of fn.apply

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -21,7 +21,7 @@
         return function() {
             if (called) throw new Error("Callback was already called.");
             called = true;
-            fn.apply(root, arguments);
+            _call(root, fn, arguments);
         }
     }
 
@@ -69,6 +69,23 @@
         }
         return keys;
     };
+
+    var _call = function(ctx, fn, args) {
+        switch (args.length) {
+            case 0:
+                return fn.call(ctx);
+            case 1:
+                return fn.call(ctx, args[0]);
+            case 2:
+                return fn.call(ctx, args[0], args[1]);
+            case 3:
+                return fn.call(ctx, args[0], args[1], args[2]);
+            case 4:
+                return fn.call(ctx, args[0], args[1], args[2], args[3]);
+            default:
+                return fn.apply(ctx, args);
+        }
+    }
 
     //// exported async module functions ////
 
@@ -148,7 +165,7 @@
 
     async.eachLimit = function (arr, limit, iterator, callback) {
         var fn = _eachLimit(limit);
-        fn.apply(null, [arr, iterator, callback]);
+        _call(null, fn, [arr, iterator, callback]);
     };
     async.forEachLimit = async.eachLimit;
 
@@ -196,19 +213,19 @@
     var doParallel = function (fn) {
         return function () {
             var args = Array.prototype.slice.call(arguments);
-            return fn.apply(null, [async.each].concat(args));
+            return _call(null, fn, [async.each].concat(args));
         };
     };
     var doParallelLimit = function(limit, fn) {
         return function () {
             var args = Array.prototype.slice.call(arguments);
-            return fn.apply(null, [_eachLimit(limit)].concat(args));
+            return _call(null, fn, [_eachLimit(limit)].concat(args));
         };
     };
     var doSeries = function (fn) {
         return function () {
             var args = Array.prototype.slice.call(arguments);
-            return fn.apply(null, [async.eachSeries].concat(args));
+            return _call(null, fn, [async.eachSeries].concat(args));
         };
     };
 
@@ -473,7 +490,7 @@
         var wrapIterator = function (iterator) {
             return function (err) {
                 if (err) {
-                    callback.apply(null, arguments);
+                    _call(null, callback, arguments);
                     callback = function () {};
                 }
                 else {
@@ -486,7 +503,7 @@
                         args.push(callback);
                     }
                     async.nextTick(function () {
-                        iterator.apply(null, args);
+                        _call(null, iterator, args);
                     });
                 }
             };
@@ -570,7 +587,7 @@
         var makeCallback = function (index) {
             var fn = function () {
                 if (tasks.length) {
-                    tasks[index].apply(null, arguments);
+                    _call(null, tasks[index], arguments);
                 }
                 return fn.next();
             };
@@ -585,8 +602,7 @@
     async.apply = function (fn) {
         var args = Array.prototype.slice.call(arguments, 1);
         return function () {
-            return fn.apply(
-                null, args.concat(Array.prototype.slice.call(arguments))
+            return _call(null, fn, args.concat(Array.prototype.slice.call(arguments))
             );
         };
     };
@@ -748,7 +764,7 @@
                     var next = function () {
                         workers -= 1;
                         if (task.callback) {
-                            task.callback.apply(task, arguments);
+                            _call(task, task.callback, arguments);
                         }
                         if (q.drain && q.tasks.length + workers === 0) {
                             q.drain();
@@ -760,10 +776,10 @@
 
                         if (sync) {
                             async.nextTick(function () {
-                                next.apply(null, cbArgs);
+                                _call(null, next, cbArgs);
                             });
                         } else {
-                            next.apply(null, arguments);
+                            _call(null, next, arguments);
                         }
                     });
                     worker(task.data, cb);
@@ -828,7 +844,7 @@
                     var args = arguments;
                     _each(ts, function (data) {
                         if (data.callback) {
-                            data.callback.apply(null, args);
+                            _call(null, data.callback, args);
                         }
                     });
 
@@ -848,7 +864,7 @@
     var _console_fn = function (name) {
         return function (fn) {
             var args = Array.prototype.slice.call(arguments, 1);
-            fn.apply(null, args.concat([function (err) {
+            _call(null, fn, args.concat([function (err) {
                 var args = Array.prototype.slice.call(arguments, 1);
                 if (typeof console !== 'undefined') {
                     if (err) {
@@ -880,21 +896,21 @@
         var memoized = function () {
             var args = Array.prototype.slice.call(arguments);
             var callback = args.pop();
-            var key = hasher.apply(null, args);
+            var key = _call(null, hasher, args);
             if (key in memo) {
-                callback.apply(null, memo[key]);
+                _call(null, callback, memo[key]);
             }
             else if (key in queues) {
                 queues[key].push(callback);
             }
             else {
                 queues[key] = [callback];
-                fn.apply(null, args.concat([function () {
+                _call(null, fn, args.concat([function () {
                     memo[key] = arguments;
                     var q = queues[key];
                     delete queues[key];
                     for (var i = 0, l = q.length; i < l; i++) {
-                      q[i].apply(null, arguments);
+                      _call(null, q[i], arguments);
                     }
                 }]));
             }
@@ -933,14 +949,14 @@
             var args = Array.prototype.slice.call(arguments);
             var callback = args.pop();
             async.reduce(fns, args, function (newargs, fn, cb) {
-                fn.apply(that, newargs.concat([function () {
+                _call(that, fn, newargs.concat([function () {
                     var err = arguments[0];
                     var nextargs = Array.prototype.slice.call(arguments, 1);
                     cb(err, nextargs);
                 }]))
             },
             function (err, results) {
-                callback.apply(that, [err].concat(results));
+                _call(that, callback, [err].concat(results));
             });
         };
     };
@@ -951,13 +967,13 @@
             var args = Array.prototype.slice.call(arguments);
             var callback = args.pop();
             return async.each(fns, function (fn, cb) {
-                fn.apply(that, args.concat([cb]));
+                _call(that, fn, args.concat([cb]));
             },
             callback);
         };
         if (arguments.length > 1) {
             var args = Array.prototype.slice.call(arguments, 1);
-            return go.apply(this, args);
+            return _call(this, go, args);
         }
         else {
             return go;


### PR DESCRIPTION
Optimize the usage of fn.apply, by using fn.call whenever possible results in at least 100% performance increase over just using fn.apply.

The benchmark is here:
http://jsperf.com/callorapply-vs-apply

The performance increase is twice as fast on Chrome. And ridiculously faster on Firefox (looks like 700% increase).

It is just microseconds after all. But shaving microseconds off a latency sensitive operations matters. And the savings adds up over time. Also considering async's job relies heavily on calling functions it should see real benefits.

It doesn't add any real bulk or complexity to existing code, the only downside is, it adds a few bytes (browser only).

Doesn't break current tests, all tests passing without modification.
