### PR TITLE
fixes setImmediate is undefined error for gecko/webkit browsers

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -79,10 +79,10 @@
             async.nextTick = setImmediate;
         }
         else {
-            async.setImmediate = async.nextTick;
             async.nextTick = function (fn) {
                 setTimeout(fn, 0);
             };
+            async.setImmediate = async.nextTick;
         }
     }
     else {


### PR DESCRIPTION
Hi there,

Ran into this problem using in Chrome: the source was defining async.setImmediate as async.nextTick before async.nextTick's definition, causing async.waterfall to fail for me, so I simply swapped the order.

Thanks for the great lib, I appreciate it.
