### PR TITLE
Detect the absence of setImmediate for nodejs-v0.8 and lesser

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -87,7 +87,12 @@
     }
     else {
         async.nextTick = process.nextTick;
-        async.setImmediate = setImmediate;
+        if (typeof setImmediate === 'function') {
+            async.setImmediate = setImmediate;
+        }
+        else {
+            async.setImmediate = async.nextTick;
+        }
     }
 
     async.each = function (arr, iterator, callback) {


### PR DESCRIPTION
And fallback to process.nextTick.

Here is how it fails on cloudfoundry's v0.8.2 without this patch:
/var/vcap/data/dea/apps/stoic-0-bda8723f9d67b2926c82dcae327b7902/app/node_modules/async/lib/async.js:90
        async.setImmediate = setImmediate;
                             ^
ReferenceError: setImmediate is not defined
    at /var/vcap/data/dea/apps/stoic-0-bda8723f9d67b2926c82dcae327b7902/app/node_modules/async/lib/async.js:90:30
    at Object.<anonymous> (/var/vcap/data/dea/apps/stoic-0-bda8723f9d67b2926c82dcae327b7902/app/node_modules/async/lib/async.js:947:2)
    at Module._compile (module.js:449:26)
