### PR TITLE
add async.cond, aliased as async.if

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -90,6 +90,14 @@
         async.setImmediate = setImmediate;
     }
 
+    async.cond = function (test, consequent, alternate, callback) {
+        test(function (err, testResult) {
+            if (err) return callback(err);
+            testResult ? consequent(callback) : alternate(callback);
+        });
+    };
+    async['if'] = async.cond;
+
     async.each = function (arr, iterator, callback) {
         callback = callback || function () {};
         if (!arr.length) {

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -66,6 +66,29 @@ function getFunctionsObject(call_order) {
     };
 }
 
+exports['cond'] = function(test) {
+    var yesFn = function (cb) { return cb(null, true); },
+        noFn = function (cb) { return cb(null, false); },
+        errFn = function (cb) { return cb(new Error); },
+        oneFn = function (cb) { return cb(null, 'one'); },
+        twoFn = function (cb) { return cb(null, 'two'); };
+    test.expect(7);
+    test.equal(async.cond, async['if']);
+    async.cond(yesFn, oneFn, twoFn, function(err, result) {
+        test.equal(err, null);
+        test.equal(result, 'one');
+        async.cond(noFn, oneFn, twoFn, function(err, result) {
+            test.equal(err, null);
+            test.equal(result, 'two');
+            async.cond(errFn, oneFn, twoFn, function(err, result) {
+                test.ok(err);
+                test.equal(result, null);
+                test.done();
+            });
+        });
+    });
+};
+
 exports['forever'] = function (test) {
     test.expect(1);
     var counter = 0;


### PR DESCRIPTION
I just tried out this project and was amazed to find out that there was no conditional evaluation equivalent under the "control flow" section. I did my best to search through the issues, but didn't see any requests for it. So here's my version.

Its usage is pretty straightforward. You provide a `test`, which chooses which callback to call, along with a `consequent` and an `alternate`, which produce possibly-different values for the final argument, the `continuation`. Errors are passed along as the first argument, as seems to be the idiom. I used dynamic member access to set the `if` member since I wasn't sure if you support ES3 environments.
