### PR TITLE
Fix setImmediate browser polyfill

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -79,10 +79,10 @@
             async.nextTick = setImmediate;
         }
         else {
-            async.setImmediate = async.nextTick;
             async.nextTick = function (fn) {
                 setTimeout(fn, 0);
             };
+            async.setImmediate = async.nextTick;
         }
     }
     else {


### PR DESCRIPTION
`setImmediate` was defined as an alias for `nextTick` too soon. This fixes the issue.
