### PR TITLE
TypeError: Property 'setImmediate' of object #<Object> is not a function fix

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -78,11 +78,11 @@
             async.setImmediate = setImmediate;
             async.nextTick = setImmediate;
         }
-        else {
-            async.setImmediate = async.nextTick;
+        else {            
             async.nextTick = function (fn) {
                 setTimeout(fn, 0);
             };
+            async.setImmediate = async.nextTick;
         }
     }
     else {


### PR DESCRIPTION
fix for "TypeError: Property 'setImmediate' of object #<Object> is not a function" in browsers.
