### PR TITLE
async.setImmediate is undefined in a browser

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -79,10 +79,10 @@
             async.nextTick = setImmediate;
         }
         else {
-            async.setImmediate = async.nextTick;
             async.nextTick = function (fn) {
                 setTimeout(fn, 0);
             };
+            async.setImmediate = async.nextTick;
         }
     }
     else {


### PR DESCRIPTION
When assigning setImmediate and nextTick in a browser, had to flip the order of assignment.
