### PR TITLE
Uncaught TypeError: Property 'setImmediate' of object #<Object> is not a function 

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -79,10 +79,10 @@
             async.nextTick = setImmediate;
         }
         else {
-            async.setImmediate = async.nextTick;
             async.nextTick = function (fn) {
                 setTimeout(fn, 0);
             };
+            async.setImmediate = async.nextTick;
         }
     }
     else {


### PR DESCRIPTION
this pull moves assignment of async.setImmediate to after assignment of async.nextTick

thought it was preserving previous value of nextTick... assuming it was just a typo?

Didn't add a test, as there is no browser-based test suite yet, but could if that would get this pull accepted!
