### PR TITLE
Fixed broken Array check in #waterfall

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -466,7 +466,7 @@
 
     async.waterfall = function (tasks, callback) {
         callback = callback || function () {};
-        if (Array.isArray(tasks)) {
+        if (!Array.isArray(tasks)) {
           var err = new Error('First argument to waterfall must be an array of functions');
           return callback(err);
         }


### PR DESCRIPTION
Calling `tasks.constructor` is not 100% safe as certain libraries may alter constructors.

Using language standard `Array.isArray` provides for accurate duck typing. 
