### PR TITLE
Possible bug fix.  async.nextTick is not a func

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -79,10 +79,10 @@
             async.nextTick = setImmediate;
         }
         else {
-            async.setImmediate = async.nextTick;
             async.nextTick = function (fn) {
                 setTimeout(fn, 0);
             };
+            async.setImmediate = async.nextTick;
         }
     }
     else {


### PR DESCRIPTION
Line 82 sets async.setImmediate = async.nextTick; the problem is that nextTick is not a defined function.  Reversing the order switch lines 82 and 83) appears to fix the issue.  I am not positive this does not adversely affect other areas.
