### PR TITLE
Use setImmediate to fix stack overflows in eachSeries.

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -136,12 +136,12 @@
                         callback(null);
                     }
                     else {
-                        setImmediate(iterate);
+                        async.setImmediate(iterate);
                     }
                 }
             });
         };
-        setImmediate(iterate);
+        async.setImmediate(iterate);
     };
     async.forEachSeries = async.eachSeries;
 


### PR DESCRIPTION
async.eachSeries causes stack overflows for large lists.

```
process.version; // => "v0.10.4"
var async = require("async");
var _ = require("underscore");

var count = 0;
async.eachSeries(_.range(10000), function(n, callback) {
    count += n;
    callback();
}, function(err) {
    console.log(count);
});
```

Before:

```
RangeError: Maximum call stack size exceeded
```

After:

```
49995000
```
