### PR TITLE
pass partial results object as second argument to tasks in .series()

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -221,7 +221,7 @@
             iterator(x.value, function (err, v) {
                 results[x.index] = v;
                 callback(err);
-            });
+            }, results);
         }, function (err) {
             callback(err, results);
         });
@@ -540,7 +540,7 @@
     async.series = function (tasks, callback) {
         callback = callback || function () {};
         if (tasks.constructor === Array) {
-            async.mapSeries(tasks, function (fn, callback) {
+            async.mapSeries(tasks, function (fn, callback, results) {
                 if (fn) {
                     fn(function (err) {
                         var args = Array.prototype.slice.call(arguments, 1);
@@ -548,7 +548,7 @@
                             args = args[0];
                         }
                         callback.call(null, err, args);
-                    });
+                    }, results);
                 }
             }, callback);
         }
@@ -562,7 +562,7 @@
                     }
                     results[k] = args;
                     callback(err);
-                });
+                }, results);
             }, function (err) {
                 callback(err, results);
             });


### PR DESCRIPTION
Allows .series() to function similarly to .waterfall() by passing partial results to subsequent tasks, but accumulates results instead of replacing them completely at each stage, and works with hashmaps of functions.

Example usage:

> var async = require('async');
> undefined
> async.series({
>    one: function(cb) { cb(null, 1); },
>    two: function(cb, res) { console.log('partial result', res); cb(null, 2); }
>  },
>    function(err, res) { console.log('final result', res); }
>  );
> partial result { one: 1 }
> final result { one: 1, two: 2 }
> undefined
> 
> async.series([
>    function(cb) { cb(null, 1); },
>    function(cb, res) { console.log('partial result', res); cb(null, 2); }
>    ],
>    function(err, res) { console.log('final result', res); }
>  );
> partial result [ 1 ]
> final result [ 1, 2 ]
> undefined
