### PR TITLE
Invoke iterate() via async.setImmediate() in async.eachSeries()

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -136,7 +136,9 @@
                         callback(null);
                     }
                     else {
-                        iterate();
+                        async.setImmediate(function() {
+                          iterate();
+                        });
                     }
                 }
             });


### PR DESCRIPTION
Currently if the iterator function happens to invoke the callback and then return rather than invoking the callback from some further asynchronous call, which is common if it determines it is not interested in this particular item, the stack depth increases. If a large percentage of invocations do this, the stack will eventually crash. Wrapping the call to iterate() in async.setImmediate() resolves the issue, and seems more natural than requiring every instance of code that utilizes async.eachSeries() to wrap its direct invocations of the callback.
