### PR TITLE
Add support to export as YUI module. Fixes #312

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -934,18 +934,32 @@
         next();
     };
 
+    var _exportedAsModule = false;
+
     // AMD / RequireJS
     if (typeof define !== 'undefined' && define.amd) {
         define([], function () {
             return async;
         });
+        _exportedAsModule = true;
     }
+
     // Node.js
-    else if (typeof module !== 'undefined' && module.exports) {
+    if (typeof module !== 'undefined' && module.exports) {
         module.exports = async;
+        _exportedAsModule = true;
     }
+
+    // YUI module
+    if (typeof YUI !== 'undefined' && YUI.add) {
+        YUI.add("async", function (Y) {
+            Y.async = async;
+        });
+        _exportedAsModule = true;
+    }
+
     // included directly via <script> tag
-    else {
+    if (!_exportedAsModule) {
         root.async = async;
     }
 


### PR DESCRIPTION
The YUI module name shall be "async", and can be accessed as `Y.async`.

Note that YUI can be present on browser as well as on Node.js side.

Since it is possible to have require.js + YUI or Node + YUI, I've replaced if..else conditions to independent blocks.

In case no module is exported, the `async` object shall still be attached to the global / window.
