### PR TITLE
Document queue.running() and cargo.running()

### DIFF
--- a/README.md
+++ b/README.md
@@ -934,6 +934,7 @@ The queue object returned by this function has the following properties and
 methods:
 
 * length() - a function returning the number of items waiting to be processed.
+* running() - a function returning the number of workers currently running.
 * concurrency - an integer for determining how many worker functions should be
   run in parallel. This property can be changed after a queue is created to
   alter the concurrency on-the-fly.
@@ -1007,6 +1008,7 @@ The cargo object returned by this function has the following properties and
 methods:
 
 * length() - a function returning the number of items waiting to be processed.
+* running() - a function returning the number of workers currently running.
 * payload - an integer for determining how many tasks should be
   process per round. This property can be changed after a cargo is created to
   alter the payload on-the-fly.


### PR DESCRIPTION
I needed this function today, but assumed it didn't exist because it wasn't in the docs. This commit adds two lines of documentation for .running() in "queue" and "cargo".

See issue #21 for the commit that introduced .running().
