### PR TITLE
Fix async compatibility with Internet Explorer 10

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -75,8 +75,11 @@
     //// nextTick implementation with browser-compatible fallback ////
     if (typeof process === 'undefined' || !(process.nextTick)) {
         if (typeof setImmediate === 'function') {
-            async.setImmediate = setImmediate;
-            async.nextTick = setImmediate;
+            async.nextTick = function (fn) {
+                // not a direct alias for IE10 compatibility
+                setImmediate(fn);
+            };
+            async.setImmediate = async.nextTick;
         }
         else {
             async.nextTick = function (fn) {


### PR DESCRIPTION
This fixes async to work on Internet Explorer 10. Internet Explorer 10 requires that the `setImmediate` function is not called as a method. As such, it cannot simply be aliased as `async.setImmediate` and `async.nextTick` as `Invalid calling object` error will be encountered since `setImmediate` will be called with `this` set to `async`.

Hopefully this can be merged soon, as otherwise only old versions of `async` can be used if people expect their site to work with IE10 visitors. I also added a comment in the source noting why `async.nextTick` is no longer simply an alias to `setImmedate` so it doesn't get replaced with an alias again (the original commit 4ef2984 did not use an alias for this reason).

This fixes #299.
