### PR TITLE
Pass params from doUntil/doWhilst callbacks to the test function

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -1,3 +1,4 @@
+/*jshint onevar: false, indent:4 */
 /*global setImmediate: false, setTimeout: false, console: false */
 (function () {
 
@@ -627,7 +628,8 @@
             if (err) {
                 return callback(err);
             }
-            if (test()) {
+            var args = Array.prototype.slice.call(arguments, 1);
+            if (test.apply(null, args)) {
                 async.doWhilst(iterator, test, callback);
             }
             else {
@@ -655,7 +657,8 @@
             if (err) {
                 return callback(err);
             }
-            if (!test()) {
+            var args = Array.prototype.slice.call(arguments, 1);
+            if (!test.apply(null, args)) {
                 async.doUntil(iterator, test, callback);
             }
             else {

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -1711,6 +1711,34 @@ exports['doUntil'] = function (test) {
     );
 };
 
+exports['doUntil callback params'] = function (test) {
+    var call_order = [];
+    var count = 0;
+    async.doUntil(
+        function (cb) {
+            debugger
+            call_order.push(['iterator', count]);
+            count++;
+            cb(null, count);
+        },
+        function (c) {
+            call_order.push(['test', c]);
+            return (c == 5);
+        },
+        function (err) {
+            test.same(call_order, [
+                ['iterator', 0], ['test', 1],
+                ['iterator', 1], ['test', 2],
+                ['iterator', 2], ['test', 3],
+                ['iterator', 3], ['test', 4],
+                ['iterator', 4], ['test', 5]
+            ]);
+            test.equals(count, 5);
+            test.done();
+        }
+    );
+};
+
 exports['whilst'] = function (test) {
     var call_order = [];
 
@@ -1753,6 +1781,35 @@ exports['doWhilst'] = function (test) {
         function () {
             call_order.push(['test', count]);
             return (count < 5);
+        },
+        function (err) {
+            debugger
+            test.same(call_order, [
+                ['iterator', 0], ['test', 1],
+                ['iterator', 1], ['test', 2],
+                ['iterator', 2], ['test', 3],
+                ['iterator', 3], ['test', 4],
+                ['iterator', 4], ['test', 5]
+            ]);
+            test.equals(count, 5);
+            test.done();
+        }
+    );
+};
+
+exports['doWhilst callback params'] = function (test) {
+    var call_order = [];
+
+    var count = 0;
+    async.doWhilst(
+        function (cb) {
+            call_order.push(['iterator', count]);
+            count++;
+            cb(null, count);
+        },
+        function (c) {
+            call_order.push(['test', c]);
+            return (c < 5);
         },
         function (err) {
             debugger


### PR DESCRIPTION
Pretty simple, it just passes the callback results from the `doWhilst` and `doUntil` iterators to the test function.  This allows you to do something like (contrived example):

``` javascript
async.doWhilst(pollForSomething, _.isUndefined, callback);
```

rather than

``` javascript
var value;
async.doWhilst(function(cb) {
  pollForSomething(function (err, res) {
    if(err) return cb(err);
    value = res;
    cb();
  });
},
function test() {
  return !value;
}, 
callback);
```
