### PR TITLE
Added eachParams function to support functions with more than 1 argument.

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -121,6 +121,44 @@
     };
     async.forEach = async.each;
 
+
+    async.eachParams = function (oThis, paramsArr, iterator, callback) {
+        if (oThis instanceof Array) {
+            callback = iterator;
+            iterator = paramsArr;
+            paramsArr = oThis;
+            oThis = null;
+        }
+
+        callback = callback || function () {};
+        if (!paramsArr.length) {
+            return callback();
+        }
+        var completed = 0;
+        _each(paramsArr, function (x) {
+            var clbk = only_once(function (err) {
+                if (err) {
+                    callback(err);
+                    callback = function () {};
+                }
+                else {
+                    completed += 1;
+                    if (completed >= paramsArr.length) {
+                        callback(null);
+                    }
+                }
+            });
+            if (x instanceof Array) {
+                x.push(clbk);
+            } else {
+                x = [x, clbk];
+            }
+            iterator.apply(oThis, x);
+        });
+    };
+    async.forEachParams = async.eachParams;
+
+
     async.eachSeries = function (arr, iterator, callback) {
         callback = callback || function () {};
         if (!arr.length) {

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -879,6 +879,72 @@ exports['forEach alias'] = function (test) {
     test.done();
 };
 
+exports['eachParams thisOk callback'] = function(test){
+    var count = 0;
+    async.eachParams(this, [[1,2],[1,3]], function(val1, val2, callback) {
+        count++;
+        callback();
+        test.throws(callback);
+        if (count == 2) {
+            test.done();
+        }
+    });
+};
+
+exports['eachParams thisNull callback'] = function(test){
+    var count = 0;
+    async.eachParams(null, [[1,2],[1,3]], function(val1, val2, callback) {
+        count++;
+        callback();
+        test.throws(callback);
+        if (count == 2) {
+            test.done();
+        }
+    });
+};
+
+exports['eachParams extra callback'] = function(test){
+    var count = 0;
+    async.eachParams([[1,2],[1,3]], function(val1, val2, callback) {
+        count++;
+        callback();
+        test.throws(callback);
+        if (count == 2) {
+            test.done();
+        }
+    });
+};
+
+exports['eachParams empty array'] = function(test){
+    test.expect(1);
+    async.eachParams([], function(x, callback){
+        test.ok(false, 'iterator should not be called');
+        callback();
+    }, function(err){
+        test.ok(true, 'should call callback');
+    });
+    setTimeout(test.done, 25);
+};
+
+exports['eachParams error'] = function(test){
+    test.expect(1);
+    async.eachParams([[1,2,3],[4,5,6]], function(val1, val2, val3, callback){
+        callback('error');
+    }, function(err){
+        test.equals(err, 'error');
+    });
+    setTimeout(test.done, 50);
+};
+
+exports['eachParams no callback'] = function(test){
+    async.eachParams([1], eachNoCallbackIterator.bind(this, test));
+};
+
+exports['forEachParams alias'] = function (test) {
+    test.strictEqual(async.eachParams, async.forEachParams);
+    test.done();
+};
+
 exports['eachSeries'] = function(test){
     var args = [];
     async.eachSeries([1,3,2], eachIterator.bind(this, args), function(err){


### PR DESCRIPTION
eachParams accepts:
1. 'this' object (optional)- represnets the object the function needs to be applied on.
2. Array of arrays - 'eachParams' will iterate over the given array and invoke the function give on every array. must be compliant with the function accepted params.
3. function - a function to invoke on every array in the given array.
4. callback - A callback which is called after all the iterator functions have finished, or an error has occurred.

Example:

async.eachParams([['a.txt', 'some text 1'], ['b.txt', 'some text 2']], fs.writeFile, function(err) {
        //  if any of the saves produced an error, err would equal that error
}
- This pull-request includes tests.
