### PR TITLE
Simple pause/resume for queues

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -696,8 +696,9 @@
 
         var workers = 0;
         var q = {
+            _concurrency: concurrency,
+
             tasks: [],
-            concurrency: concurrency,
             saturated: null,
             empty: null,
             drain: null,
@@ -735,6 +736,19 @@
                 return workers;
             }
         };
+        Object.defineProperty(q, 'concurrency', {
+            get: function () {
+                return this._concurrency;
+            },
+            set: function (newConcurrency) {
+                var isIncrease = newConcurrency > this._concurrency;
+                this._concurrency = newConcurrency;
+                if (isIncrease) {
+                    this.process();
+                }
+                return this._concurrency;
+            }
+        });
         return q;
     };
 


### PR DESCRIPTION
Since there are no pause/resume methods on queue, I was setting concurrency to 0 to pause and setting concurrency to n (where n > 0) and then calling process() in order to resume the queue.

To avoid having to remember to call process() each time, I moved the concurrency property to _concurrency and made concurrency a getter/setter that calls process() if concurrency increases.
