### PR TITLE
parallelCollect method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ a method of another library isn't working as an iterator, study this example:
 // Here is a simple object with an (unnecessarily roundabout) squaring method
 var AsyncSquaringLibrary = {
   squareExponent: 2,
-  square: function(number, callback){ 
+  square: function(number, callback){
     var result = Math.pow(number, this.squareExponent);
     setTimeout(function(){
       callback(null, result);
@@ -68,7 +68,7 @@ async.map([1, 2, 3], AsyncSquaringLibrary.square, function(err, result){
 async.map([1, 2, 3], AsyncSquaringLibrary.square.bind(AsyncSquaringLibrary), function(err, result){
   // result is [1, 4, 9]
   // With the help of bind we can attach a context to the iterator before
-  // passing it to async. Now the square function will be executed in its 
+  // passing it to async. Now the square function will be executed in its
   // 'home' AsyncSquaringLibrary context and the value of `this.squareExponent`
   // will be as expected.
 });
@@ -118,6 +118,7 @@ So far it's been tested in IE6, IE7, IE8, FF3.6 and Chrome 5. Usage:
 
 * [series](#series)
 * [parallel](#parallel)
+* [parallelCollect](#parallelCollect)
 * [whilst](#whilst)
 * [doWhilst](#doWhilst)
 * [until](#until)
@@ -162,8 +163,8 @@ __Arguments__
 
 * arr - An array to iterate over.
 * iterator(item, callback) - A function to apply to each item in the array.
-  The iterator is passed a callback(err) which must be called once it has 
-  completed. If no error has occured, the callback should be run without 
+  The iterator is passed a callback(err) which must be called once it has
+  completed. If no error has occured, the callback should be run without
   arguments or with an explicit null argument.
 * callback(err) - A callback which is called after all the iterator functions
   have finished, or an error has occurred.
@@ -196,11 +197,11 @@ processing. This means the iterator functions will complete in order.
 <a name="eachLimit" />
 ### eachLimit(arr, limit, iterator, callback)
 
-The same as each only no more than "limit" iterators will be simultaneously 
+The same as each only no more than "limit" iterators will be simultaneously
 running at any time.
 
 Note that the items are not processed in batches, so there is no guarantee that
- the first "limit" iterator functions will complete before any others are 
+ the first "limit" iterator functions will complete before any others are
 started.
 
 __Arguments__
@@ -208,8 +209,8 @@ __Arguments__
 * arr - An array to iterate over.
 * limit - The maximum number of iterators to run at any time.
 * iterator(item, callback) - A function to apply to each item in the array.
-  The iterator is passed a callback(err) which must be called once it has 
-  completed. If no error has occured, the callback should be run without 
+  The iterator is passed a callback(err) which must be called once it has
+  completed. If no error has occured, the callback should be run without
   arguments or with an explicit null argument.
 * callback(err) - A callback which is called after all the iterator functions
   have finished, or an error has occurred.
@@ -232,7 +233,7 @@ async.eachLimit(documents, 20, requestApi, function(err){
 
 Produces a new array of values by mapping each value in the given array through
 the iterator function. The iterator is called with an item from the array and a
-callback for when it has finished processing. The callback takes 2 arguments, 
+callback for when it has finished processing. The callback takes 2 arguments,
 an error and the transformed item from the array. If the iterator passes an
 error to this callback, the main callback for the map function is immediately
 called with the error.
@@ -245,7 +246,7 @@ __Arguments__
 
 * arr - An array to iterate over.
 * iterator(item, callback) - A function to apply to each item in the array.
-  The iterator is passed a callback(err, transformed) which must be called once 
+  The iterator is passed a callback(err, transformed) which must be called once
   it has completed with an error (which can be null) and a transformed item.
 * callback(err, results) - A callback which is called after all the iterator
   functions have finished, or an error has occurred. Results is an array of the
@@ -274,11 +275,11 @@ processing. The results array will be in the same order as the original.
 <a name="mapLimit" />
 ### mapLimit(arr, limit, iterator, callback)
 
-The same as map only no more than "limit" iterators will be simultaneously 
+The same as map only no more than "limit" iterators will be simultaneously
 running at any time.
 
 Note that the items are not processed in batches, so there is no guarantee that
- the first "limit" iterator functions will complete before any others are 
+ the first "limit" iterator functions will complete before any others are
 started.
 
 __Arguments__
@@ -286,7 +287,7 @@ __Arguments__
 * arr - An array to iterate over.
 * limit - The maximum number of iterators to run at any time.
 * iterator(item, callback) - A function to apply to each item in the array.
-  The iterator is passed a callback(err, transformed) which must be called once 
+  The iterator is passed a callback(err, transformed) which must be called once
   it has completed with an error (which can be null) and a transformed item.
 * callback(err, results) - A callback which is called after all the iterator
   functions have finished, or an error has occurred. Results is an array of the
@@ -318,7 +319,7 @@ __Arguments__
 
 * arr - An array to iterate over.
 * iterator(item, callback) - A truth test to apply to each item in the array.
-  The iterator is passed a callback(truthValue) which must be called with a 
+  The iterator is passed a callback(truthValue) which must be called with a
   boolean argument once it has completed.
 * callback(results) - A callback which is called after all the iterator
   functions have finished.
@@ -379,9 +380,9 @@ __Arguments__
 * memo - The initial state of the reduction.
 * iterator(memo, item, callback) - A function applied to each item in the
   array to produce the next step in the reduction. The iterator is passed a
-  callback(err, reduction) which accepts an optional error as its first 
-  argument, and the state of the reduction as the second. If an error is 
-  passed to the callback, the reduction is stopped and the main callback is 
+  callback(err, reduction) which accepts an optional error as its first
+  argument, and the state of the reduction as the second. If an error is
+  passed to the callback, the reduction is stopped and the main callback is
   immediately called with the error.
 * callback(err, result) - A callback which is called after all the iterator
   functions have finished. Result is the reduced value.
@@ -425,7 +426,7 @@ __Arguments__
 
 * arr - An array to iterate over.
 * iterator(item, callback) - A truth test to apply to each item in the array.
-  The iterator is passed a callback(truthValue) which must be called with a 
+  The iterator is passed a callback(truthValue) which must be called with a
   boolean argument once it has completed.
 * callback(result) - A callback which is called as soon as any iterator returns
   true, or after all the iterator functions have finished. Result will be
@@ -498,7 +499,7 @@ __Arguments__
 
 * arr - An array to iterate over.
 * iterator(item, callback) - A truth test to apply to each item in the array.
-  The iterator is passed a callback(truthValue) which must be called with a 
+  The iterator is passed a callback(truthValue) which must be called with a
   boolean argument once it has completed.
 * callback(result) - A callback which is called as soon as any iterator returns
   true, or after all the iterator functions have finished. Result will be
@@ -528,7 +529,7 @@ __Arguments__
 
 * arr - An array to iterate over.
 * iterator(item, callback) - A truth test to apply to each item in the array.
-  The iterator is passed a callback(truthValue) which must be called with a 
+  The iterator is passed a callback(truthValue) which must be called with a
   boolean argument once it has completed.
 * callback(result) - A callback which is called after all the iterator
   functions have finished. Result will be either true or false depending on
@@ -556,7 +557,7 @@ __Arguments__
 
 * arr - An array to iterate over
 * iterator(item, callback) - A function to apply to each item in the array.
-  The iterator is passed a callback(err, results) which must be called once it 
+  The iterator is passed a callback(err, results) which must be called once it
   has completed with an error (which can be null) and an array of results.
 * callback(err, results) - A callback which is called after all the iterator
   functions have finished, or an error has occurred. Results is an array containing
@@ -601,7 +602,7 @@ __Arguments__
   a callback(err, result) it must call on completion with an error (which can
   be null) and an optional result value.
 * callback(err, results) - An optional callback to run once all the functions
-  have completed. This function gets a results array (or object) containing all 
+  have completed. This function gets a results array (or object) containing all
   the result arguments passed to the task callbacks.
 
 __Example__
@@ -660,11 +661,11 @@ async.parallel.
 
 __Arguments__
 
-* tasks - An array or object containing functions to run, each function is passed 
+* tasks - An array or object containing functions to run, each function is passed
   a callback(err, result) it must call on completion with an error (which can
   be null) and an optional result value.
 * callback(err, results) - An optional callback to run once all the functions
-  have completed. This function gets a results array (or object) containing all 
+  have completed. This function gets a results array (or object) containing all
   the result arguments passed to the task callbacks.
 
 __Example__
@@ -707,25 +708,32 @@ function(err, results) {
 });
 ```
 
+<a name="parallelCollect" />
+### parallelCollect(n, callback)
+
+The same as parallel except that all tasks are performed instead of stopping at the first error.
+The errors and results of the component tasks are collected and passed as an array/object to the final callback. In
+the case of no errors, null is passed as the err argument.
+
 ---------------------------------------
 
 <a name="parallel" />
 ### parallelLimit(tasks, limit, [callback])
 
-The same as parallel only the tasks are executed in parallel with a maximum of "limit" 
+The same as parallel only the tasks are executed in parallel with a maximum of "limit"
 tasks executing at any time.
 
-Note that the tasks are not executed in batches, so there is no guarantee that 
+Note that the tasks are not executed in batches, so there is no guarantee that
 the first "limit" tasks will complete before any others are started.
 
 __Arguments__
 
-* tasks - An array or object containing functions to run, each function is passed 
+* tasks - An array or object containing functions to run, each function is passed
   a callback(err, result) it must call on completion with an error (which can
   be null) and an optional result value.
 * limit - The maximum number of tasks to run at any time.
 * callback(err, results) - An optional callback to run once all the functions
-  have completed. This function gets a results array (or object) containing all 
+  have completed. This function gets a results array (or object) containing all
   the result arguments passed to the task callbacks.
 
 ---------------------------------------
@@ -740,7 +748,7 @@ __Arguments__
 
 * test() - synchronous truth test to perform before each execution of fn.
 * fn(callback) - A function to call each time the test passes. The function is
-  passed a callback(err) which must be called once it has completed with an 
+  passed a callback(err) which must be called once it has completed with an
   optional error argument.
 * callback(err) - A callback which is called after the test fails and repeated
   execution of fn has stopped.
@@ -807,9 +815,9 @@ the error.
 
 __Arguments__
 
-* tasks - An array of functions to run, each function is passed a 
+* tasks - An array of functions to run, each function is passed a
   callback(err, result1, result2, ...) it must call on completion. The first
-  argument is an error (which can be null) and any further arguments will be 
+  argument is an error (which can be null) and any further arguments will be
   passed as arguments in order to the next task.
 * callback(err, [results]) - An optional callback to run once all the functions
   have completed. This will be passed the results of the last task's callback.
@@ -831,7 +839,7 @@ async.waterfall([
         callback(null, 'done');
     }
 ], function (err, result) {
-   // result now equals 'done'    
+   // result now equals 'done'
 });
 ```
 
@@ -923,7 +931,7 @@ a worker has completed a task, the task's callback is called.
 __Arguments__
 
 * worker(task, callback) - An asynchronous function for processing a queued
-  task, which must call its callback(err) argument when finished, with an 
+  task, which must call its callback(err) argument when finished, with an
   optional error as an argument.
 * concurrency - An integer for determining how many worker functions should be
   run in parallel.
@@ -996,7 +1004,7 @@ the worker has completed some tasks, each callback of those tasks is called.
 __Arguments__
 
 * worker(tasks, callback) - An asynchronous function for processing an array of
-  queued tasks, which must call its callback(err) argument when finished, with 
+  queued tasks, which must call its callback(err) argument when finished, with
   an optional error as an argument.
 * payload - An optional integer for determining how many tasks should be
   processed per round; if omitted, the default is unlimited.
@@ -1056,7 +1064,7 @@ the functions pass an error to their callback, that function will not complete
 will be called immediately with the error. Functions also receive an object
 containing the results of functions which have completed so far.
 
-Note, all functions are called with a results object as a second argument, 
+Note, all functions are called with a results object as a second argument,
 so it is unsafe to pass functions in the tasks object which cannot handle the
 extra argument. For example, this snippet of code:
 
@@ -1073,7 +1081,7 @@ argument, which will fail:
 fs.readFile('data.txt', 'utf-8', cb, {});
 ```
 
-Instead, wrap the call to readFile in a function which does not forward the 
+Instead, wrap the call to readFile in a function which does not forward the
 results object:
 
 ```js
@@ -1088,9 +1096,9 @@ __Arguments__
 
 * tasks - An object literal containing named functions or an array of
   requirements, with the function itself the last item in the array. The key
-  used for each function or array is used when specifying requirements. The 
-  function receives two arguments: (1) a callback(err, result) which must be 
-  called when finished, passing an error (which can be null) and the result of 
+  used for each function or array is used when specifying requirements. The
+  function receives two arguments: (1) a callback(err, result) which must be
+  called when finished, passing an error (which can be null) and the result of
   the function's execution, and (2) a results object, containing the results of
   the previously executed functions.
 * callback(err, results) - An optional callback which is called when all the
@@ -1098,7 +1106,7 @@ __Arguments__
   if any tasks pass an error to their callback. Results will always be passed
 	but if an error occurred, no other tasks will be performed, and the results
 	object will only contain partial results.
-  
+
 
 __Example__
 

--- a/lib/async.js
+++ b/lib/async.js
@@ -70,6 +70,15 @@
         return keys;
     };
 
+    var _values = function (obj) {
+        var values = [];
+        for (var k in obj) {
+            if (obj.hasOwnProperty(k)) {
+                values.push(obj[k]);
+            }
+        }
+        return values;
+    };
     //// exported async module functions ////
 
     //// nextTick implementation with browser-compatible fallback ////
@@ -534,6 +543,41 @@
 
     async.parallel = function (tasks, callback) {
         _parallel({ map: async.map, each: async.each }, tasks, callback);
+    };
+
+    async.parallelCollect = function (tasks, callback) {
+        callback = callback || function () {};
+        var newTasks = _reduce(_keys(tasks), function (memo, key) {
+            memo[key] = function (parallelCb) {
+                tasks[key](function (err) {
+                    var args = Array.prototype.slice.call(arguments, 1);
+                    if (args.length <= 1) {
+                        args = args[0];
+                    }
+                    parallelCb.call(null, null, err ? {error: err} : {result: args});
+                });
+            };
+            return memo;
+        }, {});
+
+        async.parallel(newTasks, function (unused, parallelResults) {
+            var all = _reduce(_keys(parallelResults), function (memo, key) {
+                if(parallelResults[key].error) {
+                    memo.errors[key] = parallelResults[key].error;
+                }
+                if(parallelResults[key].result) {
+                    memo.results[key] = parallelResults[key].result;
+                }
+                return memo;
+            }, {errors: {}, results: {}});
+
+            var errors = _values(all.errors);
+            if (tasks.constructor === Array) {
+                callback(errors.length > 0 ? errors : null, _values(all.results));
+            } else {
+                callback(errors.length > 0 ? all.errors : null, all.results);
+            }
+        });
     };
 
     async.parallelLimit = function(tasks, limit, callback) {

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -607,6 +607,99 @@ exports['parallel no callback'] = function(test){
     ]);
 };
 
+exports['parallelCollect'] = function (test) {
+    var call_order = [];
+    async.parallelCollect([
+        function (callback) {
+            setTimeout(function () {
+                call_order.push(1);
+                callback(null, 1);
+            }, 50);
+        }, function (callback) {
+            setTimeout(function () {
+                call_order.push(2);
+                callback(null, 2);
+            }, 100);
+        }, function (callback) {
+            setTimeout(function () {
+                call_order.push(3);
+                callback(null, 3, 3);
+            }, 25);
+        }
+    ], function (err, results) {
+        test.equals(err, null);
+        test.same(call_order, [3, 1, 2]);
+        test.same(results, [1, 2, [3, 3]]);
+        test.done();
+    });
+};
+
+exports['parallelCollect empty array'] = function (test) {
+    async.parallelCollect([], function (err, results) {
+        test.equals(err, null);
+        test.same(results, []);
+        test.done();
+    });
+};
+
+exports['parallelCollect error'] = function (test) {
+    async.parallelCollect([
+        function (callback) {
+            callback('error', 1);
+        }, function (callback) {
+            callback('error2', 2);
+        }
+    ], function (err, results) {
+        test.deepEqual(err, ['error','error2']);
+    });
+    setTimeout(test.done, 100);
+};
+
+exports['parallelCollect object error'] = function (test) {
+    async.parallelCollect({
+        one: function (callback) {
+            callback('errorOne', 1);
+        },
+        two: function (callback) {
+            callback(null, 2);
+        },
+        three: function (callback) {
+            callback('errorThree', 3);
+        },
+    }, function (err, results) {
+        test.same(err, {
+            one: 'errorOne',
+            three: 'errorThree',
+        });
+        test.same(results, {
+            two: 2
+        });
+    });
+    setTimeout(test.done, 100);
+};
+
+exports['parallelCollect no callback'] = function (test) {
+    async.parallelCollect([
+        function (callback) {callback();}, function (callback) {
+            callback();
+            test.done();
+        }, ]);
+};
+
+exports['parallelCollect object'] = function (test) {
+    var call_order = [];
+    async.parallelCollect(getFunctionsObject(call_order), function (err, results) {
+        test.equals(err, null);
+        test.same(call_order, [3, 1, 2]);
+        test.same(results, {
+            one: 1,
+            two: 2,
+            three: [3, 3]
+        });
+        test.done();
+    });
+};
+
 exports['parallel object'] = function(test){
     var call_order = [];
     async.parallel(getFunctionsObject(call_order), function(err, results){


### PR DESCRIPTION
A solution to issue #334 - regarding async parallel error handling. Added new method, tests and documentation for it.

Generally, this is a version of parallel() which, instead of failing on the first error, continues and gathers all errors. The final callback is called with the error list/object and the result list/object.

I've now implemented this functionality across a few projects - it seems to be something that would be useful in the core.
