### PR TITLE
Fix setImmediate incompatibility with IE10 even when process and process.nextTick are defined

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -91,7 +91,10 @@
     else {
         async.nextTick = process.nextTick;
         if (typeof setImmediate !== 'undefined') {
-            async.setImmediate = setImmediate;
+            async.setImmediate = function (fn) {
+              // not a direct alias for IE10 compatibility
+              setImmediate(fn);
+            };
         }
         else {
             async.setImmediate = async.nextTick;


### PR DESCRIPTION
Hello,

This references issue https://github.com/caolan/async/issues/299 . The fix sent by @dougwilson (PR https://github.com/caolan/async/pull/317) only works if process or process.nextTick are not defined. This effectively assumes that in a browser context, process.nextTick is not defined, but that's not always the case. For example, if you use browserify to create a browser version of your code, process.nextTick can be defined and in that case IE10 raises the "Invalid calling object" error. That is the case with one of my projects (the javascript database NeDB, https://github.com/louischatriot/nedb).

So I just copy-pasted @dougwilson's fix in the right section and the issue is solved.

Cheers,
Louis
