### PR TITLE
async.apply now uses Function.prototype.bind, if available.

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -588,14 +588,28 @@
         return makeCallback(0);
     };
 
-    async.apply = function (fn) {
-        var args = Array.prototype.slice.call(arguments, 1);
-        return function () {
-            return fn.apply(
-                null, args.concat(Array.prototype.slice.call(arguments))
-            );
-        };
-    };
+    async.apply = (function defineApply(testFunction) {
+        // If bind is available, use the sexy bind-based implementation.
+        if ("bind" in testFunction) {
+            return function apply(fn) {
+                // Get the arguments that were passed to this (apply) function, except for the function which is the first argument.
+                var args = Array.prototype.slice.call(arguments, 1);
+                // Prepend null to the arguments array, which will be this parameter of the returned bound function.
+                args.unshift(null);
+                // Bind the arguments to the passed function to create the bound function, and return the latter.
+                return fn.bind.apply(fn, args);
+            };
+        } else {
+            return function (fn) {
+                var args = Array.prototype.slice.call(arguments, 1);
+                return function () {
+                    return fn.apply(
+                        null, args.concat(Array.prototype.slice.call(arguments))
+                    );
+                };
+            };
+          }
+    })(_map);
 
     var _concat = function (eachfn, arr, fn, callback) {
         var r = [];


### PR DESCRIPTION
`async.apply`, which is extremely similar to `(function() {}).bind`, now uses the latter under the hood if available.

Is there a reason for async not to take advantage of `bind`?
