### PR TITLE
Fixing browser detection when running async with browserified/CommonJS

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -937,15 +937,15 @@
         next();
     };
 
+    // Node.js
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = async;
+    }
     // AMD / RequireJS
-    if (typeof define !== 'undefined' && define.amd) {
+    else if (typeof define !== 'undefined' && define.amd) {
         define([], function () {
             return async;
         });
-    }
-    // Node.js
-    else if (typeof module !== 'undefined' && module.exports) {
-        module.exports = async;
     }
     // included directly via <script> tag
     else {


### PR DESCRIPTION
This commit prevents async from dying when calling setImmediate on IE10 if the code is bundled using browserify.

Browserify creates shims for "process" and other CommonJS variables. It also adds a browser flag so libraries can differentiate between browser and Node environments.
