### PR TITLE
Add a clear function for async.queue()

### DIFF
--- a/README.md
+++ b/README.md
@@ -939,8 +939,8 @@ methods:
   alter the concurrency on-the-fly.
 * push(task, [callback]) - add a new task to the queue, the callback is called
   once the worker has finished processing the task.
-* clear() - clear all the task in task queue.
   instead of a single task, an array of tasks can be submitted. the respective callback is used for every task in the list.
+* clear() - clear all the task in task queue.
 * unshift(task, [callback]) - add a new task to the front of the queue.
 * saturated - a callback that is called when the queue length hits the concurrency and further tasks will be queued
 * empty - a callback that is called when the last item from the queue is given to a worker


### PR DESCRIPTION
Add a clear function for async.queue(),so user can clear the task queue when they need.
