### PR TITLE
fix setImmediate on IE10 within browserify

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -72,30 +72,16 @@
 
     //// exported async module functions ////
 
-    //// nextTick implementation with browser-compatible fallback ////
-    if (typeof process === 'undefined' || !(process.nextTick)) {
-        if (typeof setImmediate === 'function') {
-            async.nextTick = function (fn) {
-                // not a direct alias for IE10 compatibility
-                setImmediate(fn);
-            };
-            async.setImmediate = async.nextTick;
-        }
-        else {
-            async.nextTick = function (fn) {
-                setTimeout(fn, 0);
-            };
-            async.setImmediate = async.nextTick;
-        }
+    //// nextTick implementation with browser-compatible and browserify-compatible fallback ////
+    var _nextTick = (typeof process !== 'undefined' && process.nextTick);
+    var _setTimeout = function(fn) { setTimeout(fn, 0); };
+    if (typeof setImmediate === 'function') {
+      // wrap setImmediate for IE10 compatibility
+      async.setImmediate = function(fn) { setImmediate(fn); };
+      async.nextTick = _nextTick || async.setImmediate;
     }
     else {
-        async.nextTick = process.nextTick;
-        if (typeof setImmediate !== 'undefined') {
-            async.setImmediate = setImmediate;
-        }
-        else {
-            async.setImmediate = async.nextTick;
-        }
+      async.nextTick = async.setImmediate = _nextTick || _setTimeout;
     }
 
     async.each = function (arr, iterator, callback) {


### PR DESCRIPTION
Fixes async.setImmediate on IE10 when running under browserify.
