### PR TITLE
Added getter and setter

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -265,6 +265,36 @@
     // foldr alias
     async.foldr = async.reduceRight;
 
+    // setter and getter (for use in map, foldl, waterfall, etc)
+    
+    async.get = function(obj, prop, callback) {
+        if (!obj) {
+            callback();
+        }
+        callback(null,obj[prop]);
+    }
+
+    async.getter = function(prop) {
+        return function(obj, callback) {
+            async.get(obj, prop, callback);
+        }
+    }
+
+    async.set = function(obj, prop, val, callback) {
+        if (!obj) {
+            callback();
+        }
+        obj[prop] = val;
+        callback(null,val);
+    }
+
+    async.setter = function(obj, prop, callback) {
+        return function(err, val) {
+            if (err) callback(err);
+            else async.set(obj, prop, val, callback);
+        }
+    }
+
     var _filter = function (eachfn, arr, iterator, callback) {
         var results = [];
         arr = _map(arr, function (x, i) {


### PR DESCRIPTION
Some example applications:

A somewhat lengthy e-commerce example:

``` javascript
function createPayment(buyerName, sellerName, itemId, cb) {
    var scope = {}
    async.series([
        function(cb2) { 
            User.findOne({ name: buyerName }, async.setter(scope, 'buyer', cb2))
        }, function(cb2) {
            User.findOne({ name: sellerName }, async.setter(scope, 'seller', cb2))
        }, function(cb2) {
            Item.findOne({ user: scope.seller, itemId: itemId }, async.setter(scope, 'item', cb2))
        }, function(cb2) { 
            calculatePrice(scope.buyer, scope.item, async.setter(scope, 'price', cb2))
        }, function(cb2) { 
            generatePaymentRequestData(buyer, scope.seller, scope.price, async.setter(scope, 'request', cb2)) 
        }, function(cb2) { 
            PaymentRequest.insert(scope.request, cb) 
        }
    ]);
}
```

With async.waterfall, all of the intermediate data would need to be threaded through the entire computation. Here, everything stays as series of clean one-liners that looks almost like imperative code.

``` javascript
function getRequestedAmount(reqId, cb) {
    async.waterfall([
        function(cb2) { PaymentRequest.findOne({ reqId: reqId }, cb2),
        async.getter('price')
    ],cb);
}
```

And so forth.
