### PR TITLE
Enable compatibility with IE10 and browserify

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -90,8 +90,12 @@
     }
     else {
         async.nextTick = process.nextTick;
-        if (typeof setImmediate !== 'undefined') {
-            async.setImmediate = setImmediate;
+        if (typeof setImmediate === 'function') {
+            setImmediateWrap = function (fn) {
+                // not a direct alias for IE10 compatibility
+                setImmediate(fn);
+            }
+            async.setImmediate = setImmediateWrap;
         }
         else {
             async.setImmediate = async.nextTick;


### PR DESCRIPTION
Added a wrapper to `setImmediate` because `async.setImmediate` was throwing "Invalid Calling Object" errors in IE10. Browserify shims the `process` variable and gives it a `nextTick` function, which necessitates this fix for both cases.

I used the same logic that the previous contributor did to work around IE10's limited usage of `setImmediate` by wrapping it in a function. Should behave the same way and eliminate issues with Browserify and IE10.
