### PR TITLE
Fix stack overflow in async.queue

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -722,7 +722,7 @@
                         if (q.drain && q.tasks.length + workers === 0) {
                             q.drain();
                         }
-                        q.process();
+                        async.setImmediate(q.process);
                     };
                     var cb = only_once(next);
                     worker(task.data, cb);

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -2061,6 +2061,15 @@ exports['queue bulk task'] = function (test) {
     }, 800);
 };
 
+exports['queue big stack'] = function (test) {
+    var q = async.queue(function (task, callback) {
+        callback();
+    }, 1);
+    var i;
+    for (i = 0 ; i < 10000 ; i++) q.push(1);
+    q.drain = test.done;
+};
+
 exports['cargo'] = function (test) {
     var call_order = [],
         delays = [160, 160, 80];


### PR DESCRIPTION
Which happened when too many synchronous tasks were queued.

This should fix #413, although one test still fails
