### PR TITLE
Changed the order of exporting async for using browserify to create apps beside requireJS using apps

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -937,15 +937,15 @@
         next();
     };
 
+    // Node.js
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = async;
+    }
     // AMD / RequireJS
-    if (typeof define !== 'undefined' && define.amd) {
+    else if (typeof define !== 'undefined' && define.amd) {
         define([], function () {
             return async;
         });
-    }
-    // Node.js
-    else if (typeof module !== 'undefined' && module.exports) {
-        module.exports = async;
     }
     // included directly via <script> tag
     else {


### PR DESCRIPTION
Changed the order of exporting async by module-type first, because if us...ing browserify to build an app it will conflict with existing apps usigin requireJS and it does not matter for the requireJS use case if before testing for existence of module.exports
