### PR TITLE
Document queue.running()

### DIFF
--- a/README.md
+++ b/README.md
@@ -945,6 +945,7 @@ The queue object returned by this function has the following properties and
 methods:
 
 * length() - a function returning the number of items waiting to be processed.
+* running() - a function returning the number of workers currently running.
 * concurrency - an integer for determining how many worker functions should be
   run in parallel. This property can be changed after a queue is created to
   alter the concurrency on-the-fly.


### PR DESCRIPTION
I wasn't sure if queue.running() was deliberately an undocumented function, but for me it's very useful so this adds it to the docs.
