### PR TITLE
Added parallelEach

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -536,6 +536,18 @@
         _parallel({ map: async.map, each: async.each }, tasks, callback);
     };
 
+    async.parallelEach = function (arr, iterator, callback) {
+        var tasks = arr.map(function(item) {
+            return function iteratorWrapper(callback) {
+                iterator(item, function(err, res) {
+                    callback(err, res);
+                });
+            }
+        });
+
+        _parallel({ map: async.map, each: async.each}, tasks, callback);
+    };
+
     async.parallelLimit = function(tasks, limit, callback) {
         _parallel({ map: _mapLimit(limit), each: _eachLimit(limit) }, tasks, callback);
     };

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -621,6 +621,22 @@ exports['parallel object'] = function(test){
     });
 };
 
+exports['parallel each'] = function(test) {
+    var init_order = [150, 20, 80],
+        call_order = [];
+    async.parallelEach(init_order, function(item, callback){
+        setTimeout(function(){
+            call_order.push(item);
+            callback(null, item);
+        }, item);
+    }, function(err, results) {
+        test.equals(err, null);
+        test.same(call_order, [20, 80, 150]);
+        test.same(results, init_order);
+        test.done();
+    });
+};
+
 exports['parallel limit'] = function(test){
     var call_order = [];
     async.parallelLimit([


### PR DESCRIPTION
Added `parallelEach` function, sometimes we need to execute only one iterator in parallel, but current _parallel_ related functions don't support this functionality. So I wrote my own.
# parallelEach(arr, iterator, callback)
## arguments
- arr - An array to iterate over.
- iterator(item, callback) - A function to apply to each item in the array.The iterator is passed a callback(err, result) it must call on completion with an error (which can be null) and an optional result value.
- callback(err, results) - An optional callback to run once all the functions have completed. This function gets a results array (or object) containing all the result arguments passed to the task callbacks.

Example:

``` javascript
async.parallelEach([100, 50, 150], function(item, callback){
        setTimeout(function(){
            console.log(item); //It will print the result as the order of 50, 100, 150
            callback(null, item);
        }, item);
}, function(err, results) {
   //the results array will equal [100, 50, 150].
});
```
