### PR TITLE
Queue calls drain if empty task list is pushed

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -675,6 +675,14 @@
           if(data.constructor !== Array) {
               data = [data];
           }
+          if(data.length == 0) {
+             // call drain immediately if there are no tasks
+             return async.setImmediate(function() {
+                 if (q.drain) {
+                     q.drain();
+                 }
+             });
+          }
           _each(data, function(task) {
               var item = {
                   data: task,

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -2436,3 +2436,25 @@ exports['queue events'] = function(test) {
     q.push('poo', function () {calls.push('poo cb');});
     q.push('moo', function () {calls.push('moo cb');});
 };
+
+exports['queue empty'] = function(test) {
+    var calls = [];
+    var q = async.queue(function(task, cb) {
+        // nop
+        calls.push('process ' + task);
+        async.setImmediate(cb);
+    }, 3);
+
+    q.drain = function() {
+        test.ok(
+            q.length() == 0 && q.running() == 0,
+            'queue should be empty now and no more workers should be running'
+        );
+        calls.push('drain');
+        test.same(calls, [
+            'drain'
+        ]);
+        test.done();
+    };
+    q.push([]);
+};


### PR DESCRIPTION
Queue calls drain if empty list is pushed

Example:

```
var q = async.queue( worker , ... )
q.drain = function() { console.log('Drained!') }
q.push([]);
```

Old functionality: The drain is not called
New functionality: With this change the drain is called after calling push with empty array.
