### PR TITLE
Added kill method to queue

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -707,6 +707,10 @@
             push: function (data, callback) {
               _insert(q, data, false, callback);
             },
+            kill: function () {
+              q.drain = null;
+              q.tasks = [];
+            },
             unshift: function (data, callback) {
               _insert(q, data, true, callback);
             },

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -2061,6 +2061,27 @@ exports['queue bulk task'] = function (test) {
     }, 800);
 };
 
+exports['queue kill'] = function (test) {
+    var q = async.queue(function (task, callback) {
+        setTimeout(function () {
+            test.ok(false, "Function should never be called");
+            callback();
+        }, 300);
+    }, 1);
+    q.drain = function() {
+        test.ok(false, "Function should never be called");
+    }
+
+    q.push(0);
+
+    q.kill();
+    
+    setTimeout(function() {
+      test.equal(q.length(), 0);
+      test.done();
+    }, 600)
+};
+
 exports['cargo'] = function (test) {
     var call_order = [],
         delays = [160, 160, 80];


### PR DESCRIPTION
This method removes the drain function and empties out the tasks array.
