### PR TITLE
only call cargo.drain once each time it's drained

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -751,6 +751,7 @@
             saturated: null,
             empty: null,
             drain: null,
+            drained: true,
             push: function (data, callback) {
                 if(data.constructor !== Array) {
                     data = [data];
@@ -760,6 +761,7 @@
                         data: task,
                         callback: typeof callback === 'function' ? callback : null
                     });
+                    cargo.drained = false;
                     if (cargo.saturated && tasks.length === payload) {
                         cargo.saturated();
                     }
@@ -769,7 +771,8 @@
             process: function process() {
                 if (working) return;
                 if (tasks.length === 0) {
-                    if(cargo.drain) cargo.drain();
+                    if(cargo.drain && !cargo.drained) cargo.drain();
+                    cargo.drained = true;
                     return;
                 }
 

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -2195,6 +2195,53 @@ exports['cargo bulk task'] = function (test) {
     }, 800);
 };
 
+exports['cargo drain once'] = function (test) {
+   
+   var c = async.cargo(function (tasks, callback) {
+      callback();
+    }, 3);
+    
+    var drainCounter = 0;
+    c.drain = function () {
+      drainCounter++;
+    }
+    
+    for(var i = 0; i < 10; i++){
+      c.push(i);
+    }
+    
+    setTimeout(function(){
+      test.equal(drainCounter, 1);
+      test.done();
+    }, 500);
+};
+
+exports['cargo drain twice'] = function (test) {
+    
+    var c = async.cargo(function (tasks, callback) {
+      callback();
+    }, 3);
+    
+    var loadCargo = function(){
+      for(var i = 0; i < 10; i++){
+        c.push(i);
+      }
+    };
+    
+    var drainCounter = 0;
+    c.drain = function () {
+      drainCounter++;
+    }
+
+    loadCargo();
+    setTimeout(loadCargo, 500);
+
+    setTimeout(function(){
+      test.equal(drainCounter, 2);
+      test.done();
+    }, 1000);
+};
+
 exports['memoize'] = function (test) {
     test.expect(4);
     var call_order = [];


### PR DESCRIPTION
Without this, cargo.drain was often called multiple times after the last task returned.
