### PR TITLE
Added splice method to queue

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -684,11 +684,11 @@
                   callback: typeof callback === 'function' ? callback : null
               };
 
-              if (pos) {
+              if (pos === true) {
                 q.tasks.unshift(item);
-              } else {
+              } else if (pos === false) {
                 q.tasks.push(item);
-              }
+              } else q.tasks.splice(pos[0], pos[1], item);
 
               if (q.saturated && q.tasks.length === concurrency) {
                   q.saturated();
@@ -709,6 +709,9 @@
             },
             unshift: function (data, callback) {
               _insert(q, data, true, callback);
+            },
+            splice: function (index, howmany, data, callback) {
+              _insert(q, data, [index, howmany], callback);
             },
             process: function () {
                 if (workers < q.concurrency && q.tasks.length) {

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -2013,6 +2013,47 @@ exports['queue unshift'] = function (test) {
     }, 100);
 };
 
+exports['queue splice'] = function (test) {
+  var queue_order = [];
+
+  var q = async.queue(function (task, callback) {
+    queue_order.push(task);
+    callback();
+  }, 1);
+
+  q.splice(0, 0, 1);
+  q.splice(1, 0, 2);
+  q.splice(2, 0, 4);
+  q.splice(3, 0, 6);
+  q.splice(2, 0, 3);
+  q.splice(4, 0, 5);
+
+  setTimeout(function () {
+    test.same(queue_order, [ 1, 2, 3, 4, 5, 6 ]);
+    test.done();
+  }, 100);
+};
+
+exports['queue splice with "howmany" argument'] = function (test) {
+  var queue_order = [];
+
+  var q = async.queue(function (task, callback) {
+    queue_order.push(task);
+    callback();
+  }, 1);
+
+  q.splice(0, 0, 2);
+  q.splice(1, 0, 2);
+  q.splice(2, 0, 4);
+  q.splice(0, 1, 1);
+  q.splice(2, 1, 3);
+
+  setTimeout(function () {
+    test.same(queue_order, [ 1, 2, 3 ]);
+    test.done();
+  }, 100);
+};
+
 exports['queue too many callbacks'] = function (test) {
     var q = async.queue(function (task, callback) {
         callback();


### PR DESCRIPTION
Splice method allows to position a new task to a specific position in the queue to manage priorities on tasks
