### PR TITLE
Fix for cargo on IE8

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -775,7 +775,7 @@
 
                 var ts = typeof payload === 'number'
                             ? tasks.splice(0, payload)
-                            : tasks.splice(0);
+                            : tasks.splice(0, tasks.length);
 
                 var ds = _map(ts, function (task) {
                     return task.data;


### PR DESCRIPTION
IE8 is strict about having a second argument to Array.splice; without the second argument, it silently fails, causing the worker to not get any work, and the cargo to spin infinitely.
