### PR TITLE
Track auto tasks using a counter results can be inserted/removed dynamically

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -402,7 +402,8 @@
     async.auto = function (tasks, callback) {
         callback = callback || function () {};
         var keys = _keys(tasks);
-        if (!keys.length) {
+        var remainingTasks = keys.length
+        if (!remainingTasks) {
             return callback(null);
         }
 
@@ -421,13 +422,14 @@
             }
         };
         var taskComplete = function () {
+            remainingTasks--
             _each(listeners.slice(0), function (fn) {
                 fn();
             });
         };
 
         addListener(function () {
-            if (_keys(results).length === keys.length) {
+            if (!remainingTasks) {
                 var theCallback = callback;
                 // prevent final callback from calling itself if it errors
                 callback = function () {};

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -554,6 +554,31 @@ exports['auto calls callback multiple times'] = function(test) {
     }, 10);
 };
 
+// Issue 462 on github: https://github.com/caolan/async/issues/462
+exports['auto modifying results causes final callback to run early'] = function(test) {
+    async.auto({
+        task1: function(callback, results){
+            results.inserted = true
+            callback(null, 'task1');
+        },
+        task2: function(callback){
+            setTimeout(function(){
+                callback(null, 'task2');
+            }, 50);
+        },
+        task3: function(callback){
+            setTimeout(function(){
+                callback(null, 'task3');
+            }, 100);
+        }
+    },
+    function(err, results){
+        test.equal(results.inserted, true)
+        test.ok(results.task3, 'task3')
+        test.done();
+    });
+};
+
 exports['waterfall'] = function(test){
     test.expect(6);
     var call_order = [];


### PR DESCRIPTION
This is a PR to resolve https://github.com/caolan/async/issues/462... not sure if there are any other steps you want mo to take. I included a test case for the issue as well following the style i saw for other issues.
