### PR TITLE
in `.auto` check “is it an array?” instead of “is it a function?”

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -32,11 +32,6 @@
         return toString.call(obj) === '[object Array]';
     };
 
-    var _isFunction = function (obj) {
-        return obj instanceof Function ||
-        toString.call(obj) === '[object Function]';
-    };
-
     var _each = function (arr, iterator) {
         if (arr.forEach) {
             return arr.forEach(iterator);
@@ -444,7 +439,7 @@
         });
 
         _each(keys, function (k) {
-            var task = _isFunction(tasks[k]) ? [tasks[k]]: tasks[k];
+            var task = _isArray(tasks[k]) ? tasks[k]: [tasks[k]];
             var taskCallback = function (err) {
                 var args = Array.prototype.slice.call(arguments, 1);
                 if (args.length <= 1) {


### PR DESCRIPTION
Improves #479 by using `_isArray` introduced in 9f57a352bbaba436db11f8885e460eaa81d97b75.
