### PR TITLE
fix #472, add internal _toString

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -28,13 +28,15 @@
 
     //// cross-browser compatiblity functions ////
 
+    var _toString = Object.prototype.toString;
+
     var _isArray = Array.isArray || function (obj) {
-        return toString.call(obj) === '[object Array]';
+        return _toString.call(obj) === '[object Array]';
     };
 
     var _isFunction = function (obj) {
         return obj instanceof Function ||
-        toString.call(obj) === '[object Function]';
+        _toString.call(obj) === '[object Function]';
     };
 
     var _each = function (arr, iterator) {


### PR DESCRIPTION
it seems global `toString` in ie8 returns always `[object Window]`,
but `Object.prototype.toString` works well.
