### PR TITLE
style(null): always send `null` as 1st arg, not `undefined`. callback-way

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -111,7 +111,7 @@
     async.each = function (arr, iterator, callback) {
         callback = callback || function () {};
         if (!arr.length) {
-            return callback();
+            return callback(null);
         }
         var completed = 0;
         _each(arr, function (x) {
@@ -125,7 +125,7 @@
           else {
               completed += 1;
               if (completed >= arr.length) {
-                  callback();
+                  callback(null);
               }
           }
         }
@@ -135,7 +135,7 @@
     async.eachSeries = function (arr, iterator, callback) {
         callback = callback || function () {};
         if (!arr.length) {
-            return callback();
+            return callback(null);
         }
         var completed = 0;
         var iterate = function () {
@@ -147,7 +147,7 @@
                 else {
                     completed += 1;
                     if (completed >= arr.length) {
-                        callback();
+                        callback(null);
                     }
                     else {
                         iterate();
@@ -170,7 +170,7 @@
         return function (arr, iterator, callback) {
             callback = callback || function () {};
             if (!arr.length || limit <= 0) {
-                return callback();
+                return callback(null);
             }
             var completed = 0;
             var started = 0;
@@ -178,7 +178,7 @@
 
             (function replenish () {
                 if (completed >= arr.length) {
-                    return callback();
+                    return callback(null);
                 }
 
                 while (running < limit && started < arr.length) {
@@ -193,7 +193,7 @@
                             completed += 1;
                             running -= 1;
                             if (completed >= arr.length) {
-                                callback();
+                                callback(null);
                             }
                             else {
                                 replenish();
@@ -286,7 +286,7 @@
                 if (v) {
                     results.push(x);
                 }
-                callback();
+                callback(null);
             });
         }, function (err) {
             callback(_map(results.sort(function (a, b) {
@@ -312,7 +312,7 @@
                 if (!v) {
                     results.push(x);
                 }
-                callback();
+                callback(null);
             });
         }, function (err) {
             callback(_map(results.sort(function (a, b) {
@@ -333,11 +333,11 @@
                     main_callback = function () {};
                 }
                 else {
-                    callback();
+                    callback(null);
                 }
             });
         }, function (err) {
-            main_callback();
+            main_callback(null);
         });
     };
     async.detect = doParallel(_detect);
@@ -350,7 +350,7 @@
                     main_callback(true);
                     main_callback = function () {};
                 }
-                callback();
+                callback(null);
             });
         }, function (err) {
             main_callback(false);
@@ -366,7 +366,7 @@
                     main_callback(false);
                     main_callback = function () {};
                 }
-                callback();
+                callback(null);
             });
         }, function (err) {
             main_callback(true);
@@ -406,7 +406,7 @@
         var keys = _keys(tasks);
         var remainingTasks = keys.length
         if (!remainingTasks) {
-            return callback();
+            return callback(null);
         }
 
         var results = {};
@@ -521,7 +521,7 @@
           return callback(err);
         }
         if (!tasks.length) {
-            return callback();
+            return callback(null);
         }
         var wrapIterator = function (iterator) {
             return function (err) {
@@ -668,7 +668,7 @@
             });
         }
         else {
-            callback();
+            callback(null);
         }
     };
 
@@ -682,7 +682,7 @@
                 async.doWhilst(iterator, test, callback);
             }
             else {
-                callback();
+                callback(null);
             }
         });
     };
@@ -697,7 +697,7 @@
             });
         }
         else {
-            callback();
+            callback(null);
         }
     };
 
@@ -711,7 +711,7 @@
                 async.doUntil(iterator, test, callback);
             }
             else {
-                callback();
+                callback(null);
             }
         });
     };

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -774,7 +774,7 @@ exports['parallel'] = function(test){
         }
     ],
     function(err, results){
-        test.equals(err, null);
+        test.strictEqual(err, null);
         test.same(call_order, [3,1,2]);
         test.same(results, [1,2,[3,3]]);
         test.done();
@@ -783,7 +783,7 @@ exports['parallel'] = function(test){
 
 exports['parallel empty array'] = function(test){
     async.parallel([], function(err, results){
-        test.equals(err, null);
+        test.strictEqual(err, null);
         test.same(results, []);
         test.done();
     });
@@ -814,7 +814,7 @@ exports['parallel no callback'] = function(test){
 exports['parallel object'] = function(test){
     var call_order = [];
     async.parallel(getFunctionsObject(call_order), function(err, results){
-        test.equals(err, null);
+        test.strictEqual(err, null);
         test.same(call_order, [3,1,2]);
         test.same(results, {
             one: 1,
@@ -849,7 +849,7 @@ exports['parallel limit'] = function(test){
     ],
     2,
     function(err, results){
-        test.equals(err, null);
+        test.strictEqual(err, null);
         test.same(call_order, [1,3,2]);
         test.same(results, [1,2,[3,3]]);
         test.done();
@@ -858,7 +858,7 @@ exports['parallel limit'] = function(test){
 
 exports['parallel limit empty array'] = function(test){
     async.parallelLimit([], 2, function(err, results){
-        test.equals(err, null);
+        test.strictEqual(err, null);
         test.same(results, []);
         test.done();
     });
@@ -890,7 +890,7 @@ exports['parallel limit no callback'] = function(test){
 exports['parallel limit object'] = function(test){
     var call_order = [];
     async.parallelLimit(getFunctionsObject(call_order), 2, function(err, results){
-        test.equals(err, null);
+        test.strictEqual(err, null);
         test.same(call_order, [1,3,2]);
         test.same(results, {
             one: 1,
@@ -924,7 +924,7 @@ exports['series'] = function(test){
         }
     ],
     function(err, results){
-        test.equals(err, null);
+        test.strictEqual(err, null);
         test.same(results, [1,2,[3,3]]);
         test.same(call_order, [1,2,3]);
         test.done();
@@ -933,7 +933,7 @@ exports['series'] = function(test){
 
 exports['series empty array'] = function(test){
     async.series([], function(err, results){
-        test.equals(err, null);
+        test.strictEqual(err, null);
         test.same(results, []);
         test.done();
     });
@@ -966,7 +966,7 @@ exports['series no callback'] = function(test){
 exports['series object'] = function(test){
     var call_order = [];
     async.series(getFunctionsObject(call_order), function(err, results){
-        test.equals(err, null);
+        test.strictEqual(err, null);
         test.same(results, {
             one: 1,
             two: 2,


### PR DESCRIPTION
- updated tests

Async made a change that switched errors to `undefined` instead of null.

First async was all `callback(null)`, see #98, then it was all
`callback()`, see #476.

The change was worth 9 bytes of gzipped JavaScript, so this is not a
good argument on a 3kb+ gzipped lib.

The accepted callback-way is to have err === null if no error.

Maybe you won't be happy with the change but still I made it to see if
you agree or not.
