### PR TITLE
Add in started attribute for queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -918,7 +918,7 @@ async.waterfall([
         callback(null, 'one', 'two');
     },
     function(arg1, arg2, callback){
-    	// arg1 now equals 'one' and arg2 now equals 'two'
+      // arg1 now equals 'one' and arg2 now equals 'two'
         callback(null, 'three');
     },
     function(arg1, callback){
@@ -1076,6 +1076,7 @@ The `queue` object returned by this function has the following properties and
 methods:
 
 * `length()` - a function returning the number of items waiting to be processed.
+* `started` - a function returning whether or not any items have been pushed and processed by the queue
 * `running()` - a function returning the number of items currently being processed.
 * `idle()` - a function returning false if there are items waiting or being processed, or true if not.
 * `concurrency` - an integer for determining how many `worker` functions should be

--- a/lib/async.js
+++ b/lib/async.js
@@ -721,6 +721,9 @@
             concurrency = 1;
         }
         function _insert(q, data, pos, callback) {
+          if (!q.started){
+            q.started = true;
+          }
           if (!_isArray(data)) {
               data = [data];
           }
@@ -758,6 +761,7 @@
             saturated: null,
             empty: null,
             drain: null,
+            started: false,
             paused: false,
             push: function (data, callback) {
               _insert(q, data, false, callback);

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -2913,3 +2913,16 @@ exports['queue empty'] = function(test) {
     };
     q.push([]);
 };
+
+exports['queue started'] = function(test) {
+
+  var calls = [];
+  var q = async.queue(function(task, cb) {});
+  
+  test.equal(q.started, false);
+  q.push([]);
+  test.equal(q.started, true);
+  test.done();
+
+};
+


### PR DESCRIPTION
This is helpful for displaying whether or not the queue has processed any jobs. 

```
q = async.queue(function(task, cb) {});

q.started; // false
q.push([]);
q.started;//true

```
