### PR TITLE
async.queue pause/resume concurrency problem

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -806,12 +806,13 @@
             pause: function () {
                 if (q.paused === true) { return; }
                 q.paused = true;
-                q.process();
             },
             resume: function () {
                 if (q.paused === false) { return; }
                 q.paused = false;
-                q.process();
+                _each(q.tasks, function(task) {
+                    async.setImmediate(q.process);
+                });
             }
         };
         return q;

--- a/lib/async.js
+++ b/lib/async.js
@@ -810,9 +810,9 @@
             resume: function () {
                 if (q.paused === false) { return; }
                 q.paused = false;
-                _each(q.tasks, function(task) {
+                for (var i = 0; i < q.tasks.length && i < q.concurrency; i++) {
                     async.setImmediate(q.process);
-                });
+                }
             }
         };
         return q;


### PR DESCRIPTION
In the async.queue I found an issue related to restart after a pause (resume) and I try to fix.
It's not simple to explain, please follow these steps:
1) for concurrency tasks are in execution
2) I pause the queue and wait for the execution of tasks finishes
3) I resume queue
4) Queue restarts but concurrency does not work: only one task is running.

Example of problem:

```javascript
var async = require("async");
var q = async.queue(function (task, callback) {
    console.log('hello ' + task.name);
    setTimeout(function() {
        callback();
    }, 2000);
}, 5);

q.pause();
q.push({name: '1'});
q.push({name: '2'});
q.push({name: '3'});
q.push({name: '4'});
q.push({name: '5'});
q.push({name: '6'});
q.push({name: '7'});
q.push({name: '8'});
q.push({name: '9'});
q.push({name: '10'});

setTimeout(function () {
    q.resume();
    }, 2500);
```
