### PR TITLE
use SVG to display Travis CI build testing status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Async.js
 
-[![Build Status via Travis CI](https://travis-ci.org/caolan/async.png?branch=master)](https://travis-ci.org/caolan/async)
+[![Build Status via Travis CI](https://travis-ci.org/caolan/async.svg?branch=master)](https://travis-ci.org/caolan/async)
 
 
 Async is a utility module which provides straight-forward, powerful functions


### PR DESCRIPTION
Rationale:
- SVG looks better on mobile devices with high pixel density
- SVG file size is smaller
