### PR TITLE
Handle undefined arguments

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -623,7 +623,11 @@
         var makeCallback = function (index) {
             var fn = function () {
                 if (tasks.length) {
-                    tasks[index].apply(null, arguments);
+                    var args = Array.prototype.slice.call(arguments, 0),
+                        next = args.pop();
+                    args.length = Math.max(args.length, tasks[index].length - 1);
+                    args.push(next);
+                    tasks[index].apply(null, args);
                 }
                 return fn.next();
             };

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -636,7 +636,7 @@ exports['retry as an embedded task'] = function(test) {
 };
 
 exports['waterfall'] = function(test){
-    test.expect(6);
+    test.expect(8);
     var call_order = [];
     async.waterfall([
         function(callback){
@@ -656,9 +656,15 @@ exports['waterfall'] = function(test){
             test.equals(arg3, 'three');
             callback(null, 'four');
         },
-        function(arg4, callback){
+        function(arg4, arg5, callback){
             call_order.push('fn4');
-            test.same(call_order, ['fn1','fn2','fn3','fn4']);
+            test.equals(arg4, 'four');
+            test.equals(arg5, undefined);
+            callback(null, 'five');
+        },
+        function(arg5, callback){
+            call_order.push('fn5');
+            test.same(call_order, ['fn1','fn2','fn3','fn4','fn5']);
             callback(null, 'test');
         }
     ], function(err){


### PR DESCRIPTION
Tasks may "resolve" (aka call `next`) with `null, 123, undefined`
while the next task is defined as `arg1, arg2, nextArg`.

Before this fix, the task would've been called with `undefined, 123, next`,
thus mistakenly passing the `next` function to `arg2`,
and leaving `nextArg` undefined.
