### PR TITLE
fix #515, add missing license header

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -1,3 +1,10 @@
+/*!
+ * async
+ * https://github.com/caolan/async
+ *
+ * Copyright 2010-2014 Caolan McMahon
+ * Released under the MIT license
+ */
 /*jshint onevar: false, indent:4 */
 /*global setImmediate: false, setTimeout: false, console: false */
 (function () {


### PR DESCRIPTION
``` js
/*!
 * async
 * https://github.com/caolan/async
 *
 * Copyright 2010-2014 Caolan McMahon
 * Released under the MIT license
 */
```
