### PR TITLE
detect callback in _asyncMap

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -234,18 +234,26 @@
 
 
     var _asyncMap = function (eachfn, arr, iterator, callback) {
-        var results = [];
         arr = _map(arr, function (x, i) {
             return {index: i, value: x};
         });
-        eachfn(arr, function (x, callback) {
-            iterator(x.value, function (err, v) {
-                results[x.index] = v;
-                callback(err);
+        if (!callback) {
+            eachfn(arr, function (x, callback) {
+                iterator(x.value, function (err) {
+                    callback(err);
+                });
             });
-        }, function (err) {
-            callback(err, results);
-        });
+        } else {
+            var results = [];
+            eachfn(arr, function (x, callback) {
+                iterator(x.value, function (err, v) {
+                    results[x.index] = v;
+                    callback(err);
+                });
+            }, function (err) {
+                callback(err, results);
+            });
+        }
     };
     async.map = doParallel(_asyncMap);
     async.mapSeries = doSeries(_asyncMap);

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -1236,6 +1236,19 @@ exports['map original untouched'] = function(test){
     });
 };
 
+exports['map without main callback'] = function(test){
+    var a = [1,2,3];
+    var r = [];
+    async.map(a, function(x, callback){
+        r.push(x);
+        callback(null);
+        if (r.length >= a.length) {
+            test.same(r, a);
+            test.done();
+        }
+    });
+};
+
 exports['map error'] = function(test){
     test.expect(1);
     async.map([1,2,3], function(x, callback){


### PR DESCRIPTION
If `callback` is provided, accumulate `results` and return it;
If not, just iterate but nothing for performance.
