### PR TITLE
Better support for require.js

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -14,7 +14,16 @@
     // global on the server, window in the browser
     var root, previous_async;
 
-    root = this;
+    if (typeof window == 'object' && this === window) {
+        root = window;
+    }
+    else if (typeof global == 'object' && this === global) {
+        root = global;
+    }
+    else {
+        root = this;
+    }
+
     if (root != null) {
       previous_async = root.async;
     }


### PR DESCRIPTION
I'm using Require.js, so `this` doesn't refer to the `window` object, so async didn't work until I made this change.