### PR TITLE
Add anyway version of map and parallel

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -240,7 +240,7 @@
             callback(err, results);
         });
     };
-    var _asyncMapAnyway = function (eachfn, arr, iterator, callback) {
+    var _asyncMapContinue = function (eachfn, arr, iterator, callback) {
         var results = [];
         var errs = [];
         arr = _map(arr, function (x, i) {
@@ -261,7 +261,7 @@
         });
     };
     async.map = doParallel(_asyncMap);
-    async.mapAnyway = doParallel(_asyncMapAnyway);
+    async.mapContinue = doParallel(_asyncMapContinue);
     async.mapSeries = doSeries(_asyncMap);
     async.mapLimit = function (arr, limit, iterator, callback) {
         return _mapLimit(limit)(arr, iterator, callback);
@@ -603,8 +603,8 @@
     async.parallel = function (tasks, callback) {
         _parallel({ map: async.map, each: async.each }, tasks, callback);
     };
-    async.parallelAnyway = function (tasks, callback) {
-        _parallel({ map: async.mapAnyway, each: async.each }, tasks, callback);
+    async.parallelContinue = function (tasks, callback) {
+        _parallel({ map: async.mapContinue, each: async.each }, tasks, callback);
     };
 
     async.parallelLimit = function(tasks, limit, callback) {

--- a/lib/async.js
+++ b/lib/async.js
@@ -240,7 +240,28 @@
             callback(err, results);
         });
     };
+    var _asyncMapAnyway = function (eachfn, arr, iterator, callback) {
+        var results = [];
+        var errs = [];
+        arr = _map(arr, function (x, i) {
+            return {index: i, value: x};
+        });
+        eachfn(arr, function (x, callback) {
+            iterator(x.value, function (err, v) {
+                if (err) {
+                    errs.push(err);
+                }
+                if (!err && v) {
+                    results.push(v);
+                }
+                callback();
+            });
+        }, function (err) {
+            callback(errs, results);
+        });
+    };
     async.map = doParallel(_asyncMap);
+    async.mapAnyway = doParallel(_asyncMapAnyway);
     async.mapSeries = doSeries(_asyncMap);
     async.mapLimit = function (arr, limit, iterator, callback) {
         return _mapLimit(limit)(arr, iterator, callback);
@@ -581,6 +602,9 @@
 
     async.parallel = function (tasks, callback) {
         _parallel({ map: async.map, each: async.each }, tasks, callback);
+    };
+    async.parallelAnyway = function (tasks, callback) {
+        _parallel({ map: async.mapAnyway, each: async.each }, tasks, callback);
     };
 
     async.parallelLimit = function(tasks, limit, callback) {

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -804,6 +804,26 @@ exports['parallel error'] = function(test){
     setTimeout(test.done, 100);
 };
 
+exports['parallelAnyway error'] = function(test){
+    async.parallelAnyway([
+        function(callback){
+            callback('error', 1);
+        },
+        function(callback){
+            callback('error2', 2);
+        },
+        function(callback){
+            callback(null, 3);
+        }
+    ],
+    function(err, results){
+        console.log(err, results)
+        test.deepEqual(results, [3]);
+        test.deepEqual(err, ['error', 'error2']);
+    });
+    setTimeout(test.done, 100);
+};
+
 exports['parallel no callback'] = function(test){
     async.parallel([
         function(callback){callback();},
@@ -1071,6 +1091,23 @@ exports['each error'] = function(test){
     }, function(err){
         test.equals(err, 'error');
     });
+    setTimeout(test.done, 50);
+};
+
+exports['mapAnyway error'] = function(test){
+    test.expect(2);
+    async.mapAnyway([1,2,3], function(x, callback){
+        if (x == 1) {
+            callback('error');
+        } else {
+            callback(null, { pluto: x })
+        }
+    }, function(err, results) {
+        console.log('uffa', err, results)
+        test.deepEqual(results, [{pluto: 2}, {pluto: 3}])
+        test.deepEqual(err, ['error']);
+    });
+
     setTimeout(test.done, 50);
 };
 

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -804,8 +804,8 @@ exports['parallel error'] = function(test){
     setTimeout(test.done, 100);
 };
 
-exports['parallelAnyway error'] = function(test){
-    async.parallelAnyway([
+exports['parallelContinue error'] = function(test){
+    async.parallelContinue([
         function(callback){
             callback('error', 1);
         },
@@ -817,7 +817,6 @@ exports['parallelAnyway error'] = function(test){
         }
     ],
     function(err, results){
-        console.log(err, results)
         test.deepEqual(results, [3]);
         test.deepEqual(err, ['error', 'error2']);
     });
@@ -1094,16 +1093,15 @@ exports['each error'] = function(test){
     setTimeout(test.done, 50);
 };
 
-exports['mapAnyway error'] = function(test){
+exports['mapContinue error'] = function(test){
     test.expect(2);
-    async.mapAnyway([1,2,3], function(x, callback){
+    async.mapContinue([1,2,3], function(x, callback){
         if (x == 1) {
             callback('error');
         } else {
             callback(null, { pluto: x })
         }
     }, function(err, results) {
-        console.log('uffa', err, results)
         test.deepEqual(results, [{pluto: 2}, {pluto: 3}])
         test.deepEqual(err, ['error']);
     });


### PR DESCRIPTION
Use mapAnyway or parallelAnyway for doing something in parallel but if some tasks fail, the others will be executed anyway. In the final callback, the first parameter is valued with all errors. For mapAnyway, the second parameter with all mapped object.
Add main test for parallelAnyway and mapAnyway.