### PR TITLE
Fixed nasty callback duplication.

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -126,8 +126,9 @@
         });
         function done(err) {
           if (err) {
-              callback(err);
+              var cb = callback;
               callback = function () {};
+              cb(err);
           }
           else {
               completed += 1;
@@ -148,8 +149,9 @@
         var iterate = function () {
             iterator(arr[completed], function (err) {
                 if (err) {
-                    callback(err);
+                    var cb = callback;
                     callback = function () {};
+                    cb(err);
                 }
                 else {
                     completed += 1;
@@ -193,8 +195,9 @@
                     running += 1;
                     iterator(arr[started - 1], function (err) {
                         if (err) {
-                            callback(err);
+                            var cb = callback;
                             callback = function () {};
+                            cb(err);
                         }
                         else {
                             completed += 1;
@@ -344,8 +347,9 @@
         eachfn(arr, function (x, callback) {
             iterator(x, function (result) {
                 if (result) {
-                    main_callback(x);
+                    var cb = main_callback;
                     main_callback = function () {};
+                    cb(x);
                 }
                 else {
                     callback();
@@ -362,8 +366,9 @@
         async.each(arr, function (x, callback) {
             iterator(x, function (v) {
                 if (v) {
-                    main_callback(true);
+                    var cb = main_callback;
                     main_callback = function () {};
+                    cb(true);
                 }
                 callback();
             });
@@ -378,8 +383,9 @@
         async.each(arr, function (x, callback) {
             iterator(x, function (v) {
                 if (!v) {
-                    main_callback(false);
+                    var cb = main_callback;
                     main_callback = function () {};
+                    cb(false);
                 }
                 callback();
             });
@@ -468,9 +474,10 @@
                         safeResults[rkey] = results[rkey];
                     });
                     safeResults[k] = args;
-                    callback(err, safeResults);
+                    var cb = callback;
                     // stop subsequent errors hitting callback multiple times
                     callback = function () {};
+                    cb(err, safeResults);
                 }
                 else {
                     results[k] = args;
@@ -541,8 +548,9 @@
         var wrapIterator = function (iterator) {
             return function (err) {
                 if (err) {
-                    callback.apply(null, arguments);
+                    var cb = callback;
                     callback = function () {};
+                    cb.apply(null, arguments);
                 }
                 else {
                     var args = Array.prototype.slice.call(arguments, 1);


### PR DESCRIPTION
I had some case where the second error response was called during the callback of the first error response in an async call before the callback could be replaced with a noop. That resulted in the error case where the callback was called twice with an error message. That was pretty hard to debug. I figured that the same error could occur at other places as well and changed it there too. It would be nice if someone could provide unit tests for these changes, else I will provide them as soon as I have time for it.