### PR TITLE
Correct spelling of 'An'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1551,7 +1551,7 @@ by `memoize`.
 __Arguments__
 
 * `fn` - The function to proxy and cache results from.
-* `hasher` - Tn optional function for generating a custom hash for storing
+* `hasher` - An optional function for generating a custom hash for storing
   results. It has all the arguments applied to it apart from the callback, and
   must be synchronous.
 


### PR DESCRIPTION
Minor fix for a typo in the documentation for `memoize()` arguments