### PR TITLE
Noop

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -10,6 +10,7 @@
 (function () {
 
     var async = {};
+    var noop = function () {};
 
     // global on the server, window in the browser
     var root, previous_async;
@@ -113,7 +114,7 @@
     }
 
     async.each = function (arr, iterator, callback) {
-        callback = callback || function () {};
+        callback = callback || noop;
         if (!arr.length) {
             return callback();
         }
@@ -124,7 +125,7 @@
         function done(err) {
           if (err) {
               callback(err);
-              callback = function () {};
+              callback = noop;
           }
           else {
               completed += 1;
@@ -137,7 +138,7 @@
     async.forEach = async.each;
 
     async.eachSeries = function (arr, iterator, callback) {
-        callback = callback || function () {};
+        callback = callback || noop;
         if (!arr.length) {
             return callback();
         }
@@ -146,7 +147,7 @@
             iterator(arr[completed], function (err) {
                 if (err) {
                     callback(err);
-                    callback = function () {};
+                    callback = noop;
                 }
                 else {
                     completed += 1;
@@ -172,7 +173,7 @@
     var _eachLimit = function (limit) {
 
         return function (arr, iterator, callback) {
-            callback = callback || function () {};
+            callback = callback || noop;
             if (!arr.length || limit <= 0) {
                 return callback();
             }
@@ -191,7 +192,7 @@
                     iterator(arr[started - 1], function (err) {
                         if (err) {
                             callback(err);
-                            callback = function () {};
+                            callback = noop;
                         }
                         else {
                             completed += 1;
@@ -342,7 +343,7 @@
             iterator(x, function (result) {
                 if (result) {
                     main_callback(x);
-                    main_callback = function () {};
+                    main_callback = noop;
                 }
                 else {
                     callback();
@@ -360,7 +361,7 @@
             iterator(x, function (v) {
                 if (v) {
                     main_callback(true);
-                    main_callback = function () {};
+                    main_callback = noop;
                 }
                 callback();
             });
@@ -376,7 +377,7 @@
             iterator(x, function (v) {
                 if (!v) {
                     main_callback(false);
-                    main_callback = function () {};
+                    main_callback = noop;
                 }
                 callback();
             });
@@ -414,7 +415,7 @@
     };
 
     async.auto = function (tasks, callback) {
-        callback = callback || function () {};
+        callback = callback || noop;
         var keys = _keys(tasks);
         var remainingTasks = keys.length
         if (!remainingTasks) {
@@ -446,7 +447,7 @@
             if (!remainingTasks) {
                 var theCallback = callback;
                 // prevent final callback from calling itself if it errors
-                callback = function () {};
+                callback = noop;
 
                 theCallback(null, results);
             }
@@ -467,7 +468,7 @@
                     safeResults[k] = args;
                     callback(err, safeResults);
                     // stop subsequent errors hitting callback multiple times
-                    callback = function () {};
+                    callback = noop;
                 }
                 else {
                     results[k] = args;
@@ -527,7 +528,7 @@
     };
 
     async.waterfall = function (tasks, callback) {
-        callback = callback || function () {};
+        callback = callback || noop;
         if (!_isArray(tasks)) {
           var err = new Error('First argument to waterfall must be an array of functions');
           return callback(err);
@@ -539,7 +540,7 @@
             return function (err) {
                 if (err) {
                     callback.apply(null, arguments);
-                    callback = function () {};
+                    callback = noop;
                 }
                 else {
                     var args = Array.prototype.slice.call(arguments, 1);
@@ -560,7 +561,7 @@
     };
 
     var _parallel = function(eachfn, tasks, callback) {
-        callback = callback || function () {};
+        callback = callback || noop;
         if (_isArray(tasks)) {
             eachfn.map(tasks, function (fn, callback) {
                 if (fn) {
@@ -600,7 +601,7 @@
     };
 
     async.series = function (tasks, callback) {
-        callback = callback || function () {};
+        callback = callback || noop;
         if (_isArray(tasks)) {
             async.mapSeries(tasks, function (fn, callback) {
                 if (fn) {


### PR DESCRIPTION
Using one single `noop` var, we can avoid creating empty function on the fly and gain (some) perf.

This is not much, but since it cost nothing and adheres to common node.js standard, i thought this was worth a little PR.