### PR TITLE
async.someLimit

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Usage:
 * [`detectSeries`](#detectSeries)
 * [`sortBy`](#sortBy)
 * [`some`](#some)
+* [`someLimit`](#someLimit)
 * [`every`](#every)
 * [`concat`](#concat)
 * [`concatSeries`](#concatSeries)
@@ -579,6 +580,27 @@ async.some(['file1','file2','file3'], fs.exists, function(result){
     // if result is true then at least one of the files exists
 });
 ```
+
+---------------------------------------
+
+<a name="someLimit" />
+### someLimit(arr, limit iterator, callback)
+
+__Alias:__ `anyLimit`
+
+The same as [`some`](#some), only no more than `limit` `iterator`s will be simultaneously 
+running at any time.
+
+__Arguments__
+
+* `arr` - An array to iterate over.
+* `limit` - The maximum number of `iterator`s to run at any time.
+* `iterator(item, callback)` - A truth test to apply to each item in the array
+  in parallel. The iterator is passed a callback(truthValue) which must be 
+  called with a boolean argument once it has completed.
+* `callback(result)` - A callback which is called as soon as any iterator returns
+  `true`, or after all the iterator functions have finished. Result will be
+  either `true` or `false` depending on the values of the async tests.
 
 ---------------------------------------
 

--- a/lib/async.js
+++ b/lib/async.js
@@ -387,6 +387,8 @@
             main_callback(false);
         });
     };
+    // anyLimit alias
+    async.anyLimit = async.someLimit;
 
     async.every = function (arr, iterator, main_callback) {
         async.each(arr, function (x, callback) {

--- a/lib/async.js
+++ b/lib/async.js
@@ -387,8 +387,6 @@
             main_callback(false);
         });
     };
-    // anyLimit alias
-    async.anyLimit = async.someLimit;
 
     async.every = function (arr, iterator, main_callback) {
         async.each(arr, function (x, callback) {

--- a/lib/async.js
+++ b/lib/async.js
@@ -373,6 +373,20 @@
     };
     // any alias
     async.any = async.some;
+    
+    async.someLimit = function(arr, limit, iterator, main_callback) {
+        async.eachLimit(arr, limit, function(x, callback) {
+            iterator(x, function(v) {
+                if (v) {
+                    main_callback(true);
+                    main_callback = function() {};
+                }
+                callback();
+            });
+        }, function(err) {
+            main_callback(false);
+        });
+    };
 
     async.every = function (arr, iterator, main_callback) {
         async.each(arr, function (x, callback) {

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -1583,6 +1583,24 @@ exports['some early return'] = function(test){
     }, 100);
 };
 
+exports['someLimit true'] = function(test){
+    async.someLimit([3,1,2], 2, function(x, callback){
+        setTimeout(function(){callback(x === 2);}, 0);
+    }, function(result){
+        test.equals(result, true);
+        test.done();
+    });
+};
+
+exports['someLimit false'] = function(test){
+    async.someLimit([3,1,2], 2, function(x, callback){
+        setTimeout(function(){callback(x === 10);}, 0);
+    }, function(result){
+        test.equals(result, false);
+        test.done();
+    });
+};
+
 exports['any alias'] = function(test){
     test.equals(async.any, async.some);
     test.done();


### PR DESCRIPTION
Was getting crashes on file IO operations involving network shares. Since async.some is a wrapper for async.each, and async.eachLimit already exists, addition appears straightforward.