### PR TITLE
Added stop function to queue

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -785,6 +785,14 @@
               q.drain = null;
               q.tasks = [];
             },
+            stop: function () {
+                // call drain right away if no worker is running
+                // else it will be called by the last worker
+                if (q.drain && workers === 0) {
+                    q.drain();
+                }
+                q.tasks = [];
+            },
             unshift: function (data, callback) {
               _insert(q, data, true, callback);
             },

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -2568,6 +2568,46 @@ exports['queue kill'] = function (test) {
     }, 600)
 };
 
+exports['queue stop'] = function (test) {
+    count = 0;
+
+    var q = async.queue(function (task, callback) {
+        setTimeout(function () {
+            count++;
+            callback();
+        }, 300);
+    }, 1);
+    q.drain = function() {
+        test.equal(count, 0);
+        test.done();
+    }
+
+    q.push(0);
+    q.stop();
+};
+
+exports['queue stop with delay'] = function (test) {
+    count = 0;
+
+    var q = async.queue(function (task, callback) {
+        setTimeout(function () {
+            count++;
+            callback();
+        }, 300);
+    }, 2);
+    q.drain = function() {
+        test.equal(count, q.concurrency);
+        test.done();
+    }
+
+    q.push(0);
+    q.push(0);
+    q.push(0);
+    setTimeout(function () {
+        q.stop();
+    }, 10);
+};
+
 exports['priorityQueue'] = function (test) {
     var call_order = [];
 


### PR DESCRIPTION
I created a stop function to help me with that scenario:
   - Stop an action that used a queue for running subtasks.
   - Know when all the running subtasks have completed.

The current kill method removes the drain callback as it should, so I added a stop function that will keep the drain.
Stop will also make sure that the drain is called if there is no active worker. I did that in case stop is called before the workers started running.