### PR TITLE
Defense for eached array alteration, fixes #557

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -121,6 +121,7 @@
             return callback();
         }
         var completed = 0;
+        var arr_length = arr.length;
         _each(arr, function (x) {
             iterator(x, only_once(done) );
         });
@@ -131,7 +132,7 @@
           }
           else {
               completed += 1;
-              if (completed >= arr.length) {
+              if (completed >= arr_length) {
                   callback();
               }
           }


### PR DESCRIPTION
Altering the array of iterables after calling each on the array makes async either call the callback several times or not call the callback at all (depending on wether you add or remove array items).

Although it is probably not a very good practise to alter the array while it is being iterated with each, sometimes the array is passed on and the person receiving the array does not know that such requirement is in place.

The current async behaviour in such situations is very problematic and this commit should fix the problems. This should fix #557 .