### PR TITLE
go 1.0 + comply with semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "description": "Higher-order functions and common patterns for asynchronous code",
     "main": "./lib/async",
     "author": "Caolan McMahon",
-    "version": "0.9.0",
+    "version": "1.0.0",
     "repository" : {
         "type" : "git",
         "url" : "https://github.com/caolan/async.git"


### PR DESCRIPTION
semver says

> Major version zero (0.y.z) is for initial development. Anything may change at any time. The public API should not be considered stable.

This means that 0.9.1 could break back compat of async, which is very sad.

`async` seems to be a rock solid production quality piece of software.

It's ready to go 1.0 and comply with semver, i.e. all new additions to the interface bump minor, and any breaking changes to the interface will bump major.