### PR TITLE
Arg validation in .waterfall() is now asynchronous

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -533,10 +533,12 @@
         callback = callback || function () {};
         if (!_isArray(tasks)) {
           var err = new Error('First argument to waterfall must be an array of functions');
-          return callback(err);
+          return async.nextTick(function(){
+            callback(err);
+          });
         }
         if (!tasks.length) {
-            return callback();
+            return async.nextTick(callback);
         }
         var wrapIterator = function (iterator) {
             return function (err) {


### PR DESCRIPTION
I noticed that the argument validation in `.waterfall()` would call the cb right away.