### PR TITLE
add memoize expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1539,7 +1539,7 @@ The results array will be in the same order as the original.
 ## Utils
 
 <a name="memoize" />
-### memoize(fn, [hasher])
+### memoize(fn, [hasher, expirems])
 
 Caches the results of an `async` function. When creating a hash to store function
 results against, the callback is omitted from the hash and an optional hash
@@ -1554,6 +1554,7 @@ __Arguments__
 * `hasher` - Tn optional function for generating a custom hash for storing
   results. It has all the arguments applied to it apart from the callback, and
   must be synchronous.
+* `expirems` - The optional time in milliseconds after which the cached result will expire
 
 __Example__
 

--- a/lib/async.js
+++ b/lib/async.js
@@ -994,19 +994,23 @@
     async.warn = _console_fn('warn');
     async.error = _console_fn('error');*/
 
-    async.memoize = function (fn, hasher) {
+    async.memoize = function (fn, hasher, expirems) {
         var memo = {};
         var queues = {};
         hasher = hasher || function (x) {
             return x;
         };
+
+        function expired(elem) {
+            return expirems && (elem.ts + expirems < new Date().getTime());
+        }
         var memoized = function () {
             var args = Array.prototype.slice.call(arguments);
             var callback = args.pop();
             var key = hasher.apply(null, args);
-            if (key in memo) {
+            if (key in memo && !expired(memo[key])) {
                 async.nextTick(function () {
-                    callback.apply(null, memo[key]);
+                    callback.apply(null, memo[key].result);
                 });
             }
             else if (key in queues) {
@@ -1015,7 +1019,7 @@
             else {
                 queues[key] = [callback];
                 fn.apply(null, args.concat([function () {
-                    memo[key] = arguments;
+                    memo[key] = {result: arguments, ts: new Date().getTime()};
                     var q = queues[key];
                     delete queues[key];
                     for (var i = 0, l = q.length; i < l; i++) {


### PR DESCRIPTION
This allows memoized functions to have an expiration time (expressed in milliseconds). In general this is backward compatible, because the expire parameter is after the hasher and is optional (falsey values are infinite). 

One issue is that you seem to expect (from your test code at least) that callers might want to directly manipulate the cache, e.g. fn. memo['foo'] = ['bar']. This would no longer be valid as the value stored at fn. memo['foo'] would be an object of the form {result: ['bar'], ts: new Date().getTime()}. 

If you feel that particular use case must be supported, I can provide a less direct implementation, e.g. fn.memo remanins unchanged and there is a different property fn.memo_ts which is the map of timestamps used for expiration.