### PR TITLE
Use all of the arguments in default memoize hasher. Fixes #575

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -998,7 +998,11 @@
         var memo = {};
         var queues = {};
         hasher = hasher || function (x) {
-            return x;
+            if (arguments.length <= 1) {
+                return x;
+            } else {
+                return Array.prototype.slice.call(arguments);
+            }
         };
         var memoized = function () {
             var args = Array.prototype.slice.call(arguments);

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -2855,7 +2855,7 @@ exports['cargo drain twice'] = function (test) {
 };
 
 exports['memoize'] = function (test) {
-    test.expect(4);
+    test.expect(5);
     var call_order = [];
 
     var fn = function (arg1, arg2, callback) {
@@ -2870,10 +2870,13 @@ exports['memoize'] = function (test) {
         test.equal(result, 3);
         fn2(1, 2, function (err, result) {
             test.equal(result, 3);
-            fn2(2, 2, function (err, result) {
+            fn2(1, 3, function (err, result) {
                 test.equal(result, 4);
-                test.same(call_order, [['fn',1,2], ['fn',2,2]]);
-                test.done();
+                fn2(2, 2, function (err, result) {
+                    test.equal(result, 4);
+                    test.same(call_order, [['fn',1,2], ['fn',1,3], ['fn',2,2]]);
+                    test.done();
+                });
             });
         });
     });


### PR DESCRIPTION
See #575 