### PR TITLE
Fix issue when array is undefined

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -117,7 +117,7 @@
 
     async.each = function (arr, iterator, callback) {
         callback = callback || function () {};
-        if (!arr.length) {
+        if (!arr || !arr.length) {
             return callback();
         }
         var completed = 0;
@@ -141,7 +141,7 @@
 
     async.eachSeries = function (arr, iterator, callback) {
         callback = callback || function () {};
-        if (!arr.length) {
+        if (!arr || !arr.length) {
             return callback();
         }
         var completed = 0;
@@ -176,7 +176,7 @@
 
         return function (arr, iterator, callback) {
             callback = callback || function () {};
-            if (!arr.length || limit <= 0) {
+            if (!arr || !arr.length || limit <= 0) {
                 return callback();
             }
             var completed = 0;


### PR DESCRIPTION
This PR is to avoid error when array is undefined. lodash does not cause error in this case.