### PR TITLE
Risk of stack overflow in eachSeries/forEachSeries

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -157,7 +157,7 @@
                         callback();
                     }
                     else {
-                        iterate();
+                        process.nextTick(iterate);
                     }
                 }
             });

--- a/lib/async.js
+++ b/lib/async.js
@@ -157,7 +157,7 @@
                         callback();
                     }
                     else {
-                        process.nextTick(iterate);
+                        async.setImmediate(iterate);
                     }
                 }
             });


### PR DESCRIPTION
The eachSeries/forEachSeries implementation will create a stack that is at least 3x the height of the list passed in.   There are probably better ways to fix this, but the easiest is to simply call process.nextTick(iterator); when looping.

i.e. Change:
```
    async.eachSeries = function (arr, iterator, callback) {
        callback = callback || function () {};
        if (!arr.length) {
            return callback();
        }
        var completed = 0;
        var iterate = function () {
            iterator(arr[completed], function (err) {
                if (err) {
                    callback(err);
                    callback = function () {};
                }
                else {
                    completed += 1;
                    if (completed >= arr.length) {
                        callback();
                    }
                    else {
                        iterate();
                    }
                }
            });
        };
        iterate();
    };
    async.forEachSeries = async.eachSeries;
```
To:
```
    async.eachSeries = function (arr, iterator, callback) {
        callback = callback || function () {};
        if (!arr.length) {
            return callback();
        }
        var completed = 0;
        var iterate = function () {
            iterator(arr[completed], function (err) {
                if (err) {
                    callback(err);
                    callback = function () {};
                }
                else {
                    completed += 1;
                    if (completed >= arr.length) {
                        callback();
                    }
                    else {
                        process.nextTick(iterate);
                    }
                }
            });
        };
        iterate();
    };
    async.forEachSeries = async.eachSeries;
```