### PR TITLE
Use setImmediate to call eachSeries iterator to prevent stack overflow

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -157,7 +157,7 @@
                         callback();
                     }
                     else {
-                        iterate();
+                        async.setImmediate(iterate);
                     }
                 }
             });


### PR DESCRIPTION
Long lists were causing "RangeError: Maximum call stack size exceeded" with the direct call to iterator().
