### PR TITLE
allow no callback for seq

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -1056,7 +1056,14 @@
         return function () {
             var that = this;
             var args = Array.prototype.slice.call(arguments);
-            var callback = args.pop();
+
+            var callback = args.slice(-1)[0];
+            if (typeof callback == 'function') {
+                args.pop();
+            } else {
+                callback = null;
+            }
+
             async.reduce(fns, args, function (newargs, fn, cb) {
                 fn.apply(that, newargs.concat([function () {
                     var err = arguments[0];
@@ -1065,7 +1072,9 @@
                 }]))
             },
             function (err, results) {
-                callback.apply(that, [err].concat(results));
+                if (callback) {
+                  callback.apply(that, [err].concat(results));
+                }
             });
         };
     };

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -348,6 +348,27 @@ exports['seq binding'] = function (test) {
     });
 };
 
+exports['seq without callback'] = function (test) {
+    test.expect(2);
+    var testerr = new Error('test');
+    var testcontext = {name: 'foo'};
+
+    var add2 = function (n, cb) {
+        test.equal(this, testcontext);
+        setTimeout(function () {
+            cb(null, n + 2);
+        }, 50);
+    };
+    var mul3 = function (n, cb) {
+        test.equal(this, testcontext);
+        setTimeout(function () {
+            test.done();
+        }, 15);
+    };
+    var add2mul3 = async.seq(add2, mul3);
+    add2mul3.call(testcontext, 3);
+}
+
 exports['auto'] = function(test){
     var callOrder = [];
     var testdata = [{test: 'test'}];


### PR DESCRIPTION
To Fix #613

In some cases, a `seq` operation is just a series of async invocation without the need to have a summarising callback. If the last argument of `seq` is not function, just treat it as no callback.

