### PR TITLE
Retry without callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1341,6 +1341,7 @@ result (if any) of the final attempt.
 
 __Arguments__
 
+* `times` - An integer indicating how many times to attempt the `task` before giving up.
 * `task(callback, results)` - A function which receives two arguments: (1) a `callback(err, result)`
   which must be called when finished, passing `err` (which can be `null`) and the `result` of 
   the function's execution, and (2) a `results` object, containing the results of

--- a/README.md
+++ b/README.md
@@ -1359,11 +1359,10 @@ __Arguments__
   which must be called when finished, passing `err` (which can be `null`) and the `result` of
   the function's execution, and (2) a `results` object, containing the results of
   the previously executed functions (if nested inside another control flow).
-* `callback(err, results)` - An optional callback which is called when the
+* `callback(err, results)` - An __sometimes optional (see below)__ callback which is called when the
   task has succeeded, or after the final failed attempt. It receives the `err` and `result` arguments of the last attempt at completing the `task`.
 
-The [`retry`](#retry) function can be used as a stand-alone control flow by passing a
-callback, as shown below:
+__The *presence* of the `callback` argument triggers the *stand-alone control flow* behavior:__
 
 ```js
 async.retry(3, apiMethod, function(err, result) {
@@ -1371,8 +1370,17 @@ async.retry(3, apiMethod, function(err, result) {
 });
 ```
 
-It can also be embeded within other control flow functions to retry individual methods
-that are not as reliable, like this:
+To use the stand alone behavior without a callback you can do any of the following:
+
+```js
+async.retry(3, apiMethod)()
+async.retry(3, apiMethod).start()
+async.retry(3, apiMethod, noop) // just provide a noop callback
+```
+
+__The *absence* of the `callback` argument triggers the *nested control flow* behavior:__
+
+The [`retry`](#retry) function can also be nested within other control flow functions to retry individual methods that are not as reliable, like this:
 
 ```js
 async.auto({

--- a/lib/async.js
+++ b/lib/async.js
@@ -525,8 +525,12 @@
                 (wrappedCallback || callback)(data.err, data.result);
             });
         }
-        // If a callback is passed, run this as a controll flow
-        return callback ? wrappedTask() : wrappedTask
+
+        // explicitly run the wrapped task (just for better readability)
+        wrappedTask.start = function() { wrappedTask() }
+
+        // If a callback is passed, run this as a control flow
+        return callback ? wrappedTask.start() : wrappedTask
     };
 
     async.waterfall = function (tasks, callback) {

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -598,7 +598,7 @@ exports['retry when attempt succeeds'] = function(test) {
     });
 };
 
-exports['retry when all attempts succeeds'] = function(test) {
+exports['retry when all attempts fail'] = function(test) {
     var times = 3;
     var callCount = 0;
     var error = 'ERROR';


### PR DESCRIPTION
Updated the docs and made one minor change (for convenience) to the retry method based on https://github.com/caolan/async/issues/597. The API is the same.

There is one failing test for me (noConflict - node only) when running `npm test` in terminal. It also fails in master.