### PR TITLE
Making async.forever run... forever =)

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -1103,7 +1103,7 @@
                 }
                 throw err;
             }
-            fn(next);
+            setImmediate(fn, next);
         }
         next();
     };


### PR DESCRIPTION
Previously, if async.forever was called, since it wasn't using `setImmediate` --
the max call stack size would be exceeded rather quickly.

This fix introduces setImmediate behavior to prevent user-generated tasks from
starving the event loop of resources.

Fixes #437.