### PR TITLE
improved seq() documentation wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -972,7 +972,8 @@ add1mul3(4, function (err, result) {
 ### seq(fn1, fn2...)
 
 Version of the compose function that is more natural to read.
-Each following function consumes the return value of the latter function. 
+Each following function consumes the return value of the former function.
+It is the equivalent of the compose function with reversed arguments.
 
 Each function is executed with the `this` binding of the composed function.
 


### PR DESCRIPTION
Two changes were made here:
- `latter` was changed to `former` (that caused a good deal of headache the other day)
- added some clarification as to what exactly differs from the `compose()` function

Since it's not entirely clear that `compose()` doesn't work left to right, `seq()` should better indicate that it does.
