### PR TITLE
Document behavior of the default hash function of async.memoize

### DIFF
--- a/README.md
+++ b/README.md
@@ -1313,6 +1313,8 @@ Caches the results of an async function. When creating a hash to store function
 results against, the callback is omitted from the hash and an optional hash
 function can be used.
 
+If no hash function is specified, the first argument is used as a hash key, which may work reasonably if it is a string or a data type that converts to a distinct string. Note that objects and arrays will not behave reasonably. Neither will cases where the other arguments are significant. In such cases, specify your own hash function.
+
 The cache of results is exposed as the `memo` property of the function returned
 by `memoize`.
 

--- a/lib/async.js
+++ b/lib/async.js
@@ -136,7 +136,9 @@
                         callback(null);
                     }
                     else {
-                        iterate();
+                        async.setImmediate(function() {
+                          iterate();
+                        });
                     }
                 }
             });

--- a/lib/async.js
+++ b/lib/async.js
@@ -136,9 +136,7 @@
                         callback(null);
                     }
                     else {
-                        async.setImmediate(function() {
-                          iterate();
-                        });
+                        iterate();
                     }
                 }
             });


### PR DESCRIPTION
This is my understanding of the default hash function of async.memoize, which isn't currently documented. Hopefully it will be accepted or corrected. Either way, I learn if I'm right!

There are three commits because github can't quite figure out I backed out an older pull request of mine, but the diff is clean.
