### PR TITLE
make callback optional in whilst

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -683,7 +683,7 @@
             });
         }
         else {
-            callback();
+            if (callback) callback();
         }
     };
 


### PR DESCRIPTION
I believe that it's a best practice to make the callback optional.

This technique is used in core node libs (see https://github.com/joyent/node/tree/master/lib) as well as many popular community projects.

Fixes #446 