### PR TITLE
Cache length in cross-browser _each() for loop

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -45,7 +45,7 @@
         if (arr.forEach) {
             return arr.forEach(iterator);
         }
-        for (var i = 0; i < arr.length; i += 1) {
+        for (var i = 0, l = arr.length; i < l; i += 1) {
             iterator(arr[i], i, arr);
         }
     };


### PR DESCRIPTION
In the for loop on line 48 the length of the array is being looked up on each iteration of the loop. This change caches the length of the array in a variable to optimize for speed. This way there is only one lookup for array length. Nothing else is changed.
LINE 48 BEFORE: for (var i = 0; i < arr.length; i += 1) {
LINE 48 AFTER: for (var i = 0, l = arr.length; i < l; i += 1) {