### PR TITLE
Removed the slower forEach in async.each

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -42,9 +42,6 @@
     };
 
     var _each = function (arr, iterator) {
-        if (arr.forEach) {
-            return arr.forEach(iterator);
-        }
         for (var i = 0; i < arr.length; i += 1) {
             iterator(arr[i], i, arr);
         }


### PR DESCRIPTION
In reference to #639, to quote @callumlocke:

why is .forEach() preferred here? it's slower - http://jsperf.com/for-vs-foreach/9

In my personal internal testing, I found no change in behavior. 
