### PR TITLE
complete conditions before call queue.drain()

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -742,7 +742,7 @@
           if (!_isArray(data)) {
               data = [data];
           }
-          if(data.length == 0) {
+          if(data.length === 0 && q.idle()) {
              // call drain immediately if there are no tasks
              return async.setImmediate(function() {
                  if (q.drain) {
@@ -862,7 +862,7 @@
           if (!_isArray(data)) {
               data = [data];
           }
-          if(data.length == 0) {
+          if(data.length === 0 && q.idle()) {
              // call drain immediately if there are no tasks
              return async.setImmediate(function() {
                  if (q.drain) {


### PR DESCRIPTION
code in async.queue:
```
if(data.length == 0) {
  // call drain immediately if there are no tasks
  return async.setImmediate(function() {
    if (q.drain) {
      q.drain();
    }
  });
}
```
If param data is [], q.drain() will be called, but the q.tasks and workers may not be empty.
So I added a condition, made it like this:
```
if(data.length === 0 && q.idle()) {
  // call drain immediately if there are no tasks
  return async.setImmediate(function() {
    if (q.drain) {
      q.drain();
    }
  });
}
```