### PR TITLE
Dereference internal "results" data structures (memory leak)

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -252,6 +252,7 @@
                 });
             }, function (err) {
                 callback(err, results);
+                results = null;
             });
         }
     };
@@ -309,6 +310,7 @@
             }), function (x) {
                 return x.value;
             }));
+            results = null;
         });
     };
     async.filter = doParallel(_filter);
@@ -335,6 +337,7 @@
             }), function (x) {
                 return x.value;
             }));
+            results = null;
         });
     };
     async.reject = doParallel(_reject);
@@ -590,6 +593,7 @@
                 });
             }, function (err) {
                 callback(err, results);
+                results = null;
             });
         }
     };
@@ -630,6 +634,7 @@
                 });
             }, function (err) {
                 callback(err, results);
+                results = null;
             });
         }
     };
@@ -668,6 +673,7 @@
             });
         }, function (err) {
             callback(err, r);
+            r = null;
         });
     };
     async.concat = doParallel(_concat);

--- a/lib/async.js
+++ b/lib/async.js
@@ -252,7 +252,6 @@
                 });
             }, function (err) {
                 callback(err, results);
-                results = null;
             });
         }
     };
@@ -673,7 +672,6 @@
             });
         }, function (err) {
             callback(err, r);
-            r = null;
         });
     };
     async.concat = doParallel(_concat);


### PR DESCRIPTION
Once “results” is passed to the callback, the method no longer needs reference to it. Setting to null will encourage Garbage Collection to clean it up. Because the callback is called from within a closure, GC doesn’t automatically recognize that “results” is no longer needed in this context.

After running numerous Heap Snapshot comparisons over time, it's clear that these methods hang onto these objects well after execution time. If the data being passed into results is very large, like in my case the page sources of URLs, the memory leaks becoming crippling after thousands of iterations.