### PR TITLE
Removing internal setImmediate's

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,42 @@ missing please create a GitHub issue for it.
 
 ## Common Pitfalls
 
+<a name="stack-overflow">
+### Synchronous iteration functions
+
+If you get an error like `RangeError: Maximum call stack size exceeded.` or other stack overflow issues when using async, you are likely using a synchronous iterator.  By *synchronous* we mean a function that calls its callback on the same tick in the javascript event loop, without doing any I/O or using any timers.  Calling many callbacks iteratively will quickly overflow the stack. If you run into this issue, just defer your callback with `async.nextTick` to start a new call stack on the next tick of the event loop.
+
+This can also arise by accident if you callback early in certain cases:
+
+```js
+async.eachSeries(hugeArray, function iterator(item, callback) {
+  if (matchesSomething(item)) {
+    callback(null); // if many items match this, you'll overflow 
+  } else {
+    doSomeIO(item, callback);
+  }
+}, function done() { 
+  //... 
+});
+```
+
+Just change it to:
+
+```js
+async.eachSeries(hugeArray, function iterator(item, callback) {
+  if (item.somePredicate()) {
+    async,nextTick(function () {
+      callback(null);
+    });
+  } else {
+    doSomeIO(item, callback);
+  //...
+```
+
+Async does not guard against synchronous functions because it adds a small performance hit for each function call.  Functions that are asynchronous by their nature do not have this problem and don't need the automatic callback deferral.
+
+If javascript's event loop is still a bit nebulous, check out [this article](http://blog.carbonfive.com/2013/10/27/the-javascript-event-loop-explained/) or [this talk](http://2014.jsconf.eu/speakers/philip-roberts-what-the-heck-is-the-event-loop-anyway.html) for more detailed information about how it works.
+
 ### Binding a context to an iterator
 
 This section is really about `bind`, not about `async`. If you are wondering how to

--- a/lib/async.js
+++ b/lib/async.js
@@ -416,45 +416,46 @@
     async.auto = function (tasks, callback) {
         callback = callback || function () {};
         var keys = _keys(tasks);
-        var remainingTasks = keys.length
-        if (!remainingTasks) {
+        if (keys.length === 0) {
             return callback();
         }
 
         var results = {};
-
+        var running = {};
         var listeners = [];
-        var addListener = function (fn) {
+
+        function addListener(fn) {
             listeners.unshift(fn);
-        };
-        var removeListener = function (fn) {
+        }
+        function removeListener(fn) {
             for (var i = 0; i < listeners.length; i += 1) {
                 if (listeners[i] === fn) {
                     listeners.splice(i, 1);
                     return;
                 }
             }
-        };
-        var taskComplete = function () {
-            remainingTasks--
+        }
+        function taskComplete() {
             _each(listeners.slice(0), function (fn) {
                 fn();
             });
-        };
+        }
 
-        addListener(function () {
-            if (!remainingTasks) {
+        function allComplete() {
+            if (listeners.length === 1) {
                 var theCallback = callback;
                 // prevent final callback from calling itself if it errors
                 callback = function () {};
-
+                removeListener(allComplete);
                 theCallback(null, results);
             }
-        });
+        }
+
+        addListener(allComplete);
 
         _each(keys, function (k) {
             var task = _isArray(tasks[k]) ? tasks[k]: [tasks[k]];
-            var taskCallback = function (err) {
+            function taskCallback(err) {
                 var args = Array.prototype.slice.call(arguments, 1);
                 if (args.length <= 1) {
                     args = args[0];
@@ -465,27 +466,35 @@
                         safeResults[rkey] = results[rkey];
                     });
                     safeResults[k] = args;
-                    callback(err, safeResults);
+
+                    var theCallback = callback;
                     // stop subsequent errors hitting callback multiple times
                     callback = function () {};
+                    theCallback(err, safeResults);
                 }
                 else {
                     results[k] = args;
-                    async.setImmediate(taskComplete);
+                    taskComplete();
                 }
-            };
+            }
             var requires = task.slice(0, Math.abs(task.length - 1)) || [];
-            var ready = function () {
+
+            function ready() {
                 return _reduce(requires, function (a, x) {
                     return (a && results.hasOwnProperty(x));
                 }, true) && !results.hasOwnProperty(k);
-            };
+            }
+
             if (ready()) {
                 task[task.length - 1](taskCallback, results);
             }
             else {
-                var listener = function () {
+                var listener = function listener() {
+                    if (running[k]) {
+                        return;
+                    }
                     if (ready()) {
+                        running[k] = true;
                         removeListener(listener);
                         task[task.length - 1](taskCallback, results);
                     }
@@ -550,9 +559,7 @@
                     else {
                         args.push(callback);
                     }
-                    async.setImmediate(function () {
-                        iterator.apply(null, args);
-                    });
+                    iterator.apply(null, args);
                 }
             };
         };

--- a/lib/async.js
+++ b/lib/async.js
@@ -425,7 +425,7 @@
         var listeners = [];
 
         function addListener(fn) {
-            listeners.unshift(fn);
+            listeners.push(fn);
         }
         function removeListener(fn) {
             for (var i = 0; i < listeners.length; i += 1) {
@@ -442,7 +442,7 @@
         }
 
         function allComplete() {
-            if (listeners.length === 1) {
+            if (listeners.length === 1 && _keys(running).length === 0) {
                 var theCallback = callback;
                 // prevent final callback from calling itself if it errors
                 callback = function () {};
@@ -451,11 +451,11 @@
             }
         }
 
-        addListener(allComplete);
 
         _each(keys, function (k) {
             var task = _isArray(tasks[k]) ? tasks[k]: [tasks[k]];
             function taskCallback(err) {
+                delete running[k];
                 var args = Array.prototype.slice.call(arguments, 1);
                 if (args.length <= 1) {
                     args = args[0];
@@ -485,23 +485,22 @@
                 }, true) && !results.hasOwnProperty(k);
             }
 
-            if (ready()) {
-                task[task.length - 1](taskCallback, results);
-            }
-            else {
-                var listener = function listener() {
-                    if (running[k]) {
-                        return;
-                    }
-                    if (ready()) {
-                        running[k] = true;
-                        removeListener(listener);
-                        task[task.length - 1](taskCallback, results);
-                    }
-                };
-                addListener(listener);
-            }
+            var listener = function listener() {
+                if (running[k]) {
+                    return;
+                }
+                if (ready()) {
+                    running[k] = true;
+                    removeListener(listener);
+                    task[task.length - 1](taskCallback, results);
+                }
+            };
+            addListener(listener);
         });
+
+        addListener(allComplete);
+
+        taskComplete();
     };
 
     async.retry = function(times, task, callback) {

--- a/lib/async.js
+++ b/lib/async.js
@@ -865,13 +865,9 @@
           if (!_isArray(data)) {
               data = [data];
           }
-          if(data.length == 0) {
-             // call drain immediately if there are no tasks
-             return async.setImmediate(function() {
-                 if (q.drain) {
-                     q.drain();
-                 }
-             });
+          if(data.length === 0 && q.idle()) {
+            // call drain immediately if there are no tasks
+            q.drain();
           }
           _each(data, function(task) {
               var item = {
@@ -882,9 +878,8 @@
 
               q.tasks.splice(_binarySearch(q.tasks, item, _compareTasks) + 1, 0, item);
 
-              if (q.tasks.length === q.concurrency) {
-                  q.saturated();
-              }
+              // need to defer so tasks pushed on the same tick will
+              // prioritize properly
               async.setImmediate(q.process);
           });
         }
@@ -904,15 +899,15 @@
     };
 
     async.cargo = function (worker, payload) {
-        var working     = false,
-            tasks       = [];
+        var working = false,
+            tasks = [];
 
         var cargo = {
             tasks: tasks,
             payload: payload,
-            saturated: null,
-            empty: null,
-            drain: null,
+            saturated: noop,
+            empty: noop,
+            drain: noop,
             drained: true,
             push: function (data, callback) {
                 if (!_isArray(data)) {
@@ -921,19 +916,22 @@
                 _each(data, function(task) {
                     tasks.push({
                         data: task,
-                        callback: typeof callback === 'function' ? callback : null
+                        callback: typeof callback === 'function' ? callback : noop
                     });
                     cargo.drained = false;
-                    if (cargo.saturated && tasks.length === payload) {
+                    if (tasks.length === payload) {
                         cargo.saturated();
                     }
                 });
+
+                // need to defer so tasks pushed on the same tick will
+                // saturate the queue
                 async.setImmediate(cargo.process);
             },
             process: function process() {
                 if (working) return;
                 if (tasks.length === 0) {
-                    if(cargo.drain && !cargo.drained) cargo.drain();
+                    if(!cargo.drained) cargo.drain();
                     cargo.drained = true;
                     return;
                 }
@@ -946,7 +944,7 @@
                     return task.data;
                 });
 
-                if(cargo.empty) cargo.empty();
+                cargo.empty();
                 working = true;
                 worker(ds, function () {
                     working = false;

--- a/lib/async.js
+++ b/lib/async.js
@@ -33,6 +33,8 @@
         }
     }
 
+    function noop () {}
+
     //// cross-browser compatiblity functions ////
 
     var _toString = Object.prototype.toString;
@@ -537,8 +539,9 @@
     async.waterfall = function (tasks, callback) {
         callback = callback || function () {};
         if (!_isArray(tasks)) {
-          var err = new Error('First argument to waterfall must be an array of functions');
-          return callback(err);
+            // would it be better to throw this?
+            return callback(new Error('First argument to waterfall must be ' +
+                'an array of functions'));
         }
         if (!tasks.length) {
             return callback();
@@ -738,6 +741,9 @@
         if (concurrency === undefined) {
             concurrency = 1;
         }
+
+        var running = 0;
+
         function _insert(q, data, pos, callback) {
           if (!q.started){
             q.started = true;
@@ -745,18 +751,14 @@
           if (!_isArray(data)) {
               data = [data];
           }
-          if(data.length == 0) {
-             // call drain immediately if there are no tasks
-             return async.setImmediate(function() {
-                 if (q.drain) {
-                     q.drain();
-                 }
-             });
+          if(data.length === 0 && q.idle()) {
+            // call drain immediately if there are no tasks
+            q.drain();
           }
           _each(data, function(task) {
               var item = {
                   data: task,
-                  callback: typeof callback === 'function' ? callback : null
+                  callback: typeof callback === 'function' ? callback : noop
               };
 
               if (pos) {
@@ -765,45 +767,43 @@
                 q.tasks.push(item);
               }
 
-              if (q.saturated && q.tasks.length === q.concurrency) {
-                  q.saturated();
-              }
-              async.setImmediate(q.process);
+              q.process();
           });
         }
 
-        var workers = 0;
         var q = {
             tasks: [],
             concurrency: concurrency,
-            saturated: null,
-            empty: null,
-            drain: null,
+            saturated: noop,
+            empty: noop,
+            drain: noop,
             started: false,
             paused: false,
             push: function (data, callback) {
               _insert(q, data, false, callback);
             },
             kill: function () {
-              q.drain = null;
+              q.drain = noop;
               q.tasks = [];
+              running = 0;
             },
             unshift: function (data, callback) {
               _insert(q, data, true, callback);
             },
             process: function () {
-                if (!q.paused && workers < q.concurrency && q.tasks.length) {
+                if (!q.paused && running < q.concurrency && q.tasks.length) {
                     var task = q.tasks.shift();
-                    if (q.empty && q.tasks.length === 0) {
-                        q.empty();
+                    running += 1;
+                    if (running === q.concurrency) {
+                        q.saturated();
                     }
-                    workers += 1;
                     var next = function () {
-                        workers -= 1;
-                        if (task.callback) {
-                            task.callback.apply(task, arguments);
+                        running -= 1;
+                        if (running === 0) {
+                            q.empty();
                         }
-                        if (q.drain && q.tasks.length + workers === 0) {
+                        task.callback.apply(task, arguments);
+                        if (q.tasks.length + running === 0) {
                             q.drain();
                         }
                         q.process();
@@ -816,10 +816,10 @@
                 return q.tasks.length;
             },
             running: function () {
-                return workers;
+                return running;
             },
             idle: function() {
-                return q.tasks.length + workers === 0;
+                return q.tasks.length + running === 0;
             },
             pause: function () {
                 if (q.paused === true) { return; }
@@ -830,8 +830,8 @@
                 q.paused = false;
                 // Need to call q.process once per concurrent
                 // worker to preserve full concurrency after pause
-                for (var w = 1; w <= q.concurrency; w++) {
-                    async.setImmediate(q.process);
+                for (var w = 0; w < q.concurrency; w++) {
+                    q.process();
                 }
             }
         };
@@ -842,7 +842,7 @@
 
         function _compareTasks(a, b){
           return a.priority - b.priority;
-        };
+        }
 
         function _binarySearch(sequence, item, compare) {
           var beg = -1,
@@ -882,7 +882,7 @@
 
               q.tasks.splice(_binarySearch(q.tasks, item, _compareTasks) + 1, 0, item);
 
-              if (q.saturated && q.tasks.length === q.concurrency) {
+              if (q.tasks.length === q.concurrency) {
                   q.saturated();
               }
               async.setImmediate(q.process);

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -384,7 +384,7 @@ exports['auto'] = function(test){
         }]
     },
     function(err){
-        test.same(callOrder, ['task2','task6','task3','task5','task1','task4']);
+        test.same(callOrder, ['task2','task3','task6','task5','task1','task4']);
         test.done();
     });
 };
@@ -489,6 +489,7 @@ exports['auto no callback'] = function(test){
 };
 
 exports['auto error should pass partial results'] = function(test) {
+    test.expect(3);
     async.auto({
         task1: function(callback){
             callback(false, 'result1');
@@ -501,6 +502,7 @@ exports['auto error should pass partial results'] = function(test) {
         }]
     },
     function(err, results){
+        console.log("auto error done")
         test.equals(err, 'testerror');
         test.equals(results.task1, 'result1');
         test.equals(results.task2, 'result2');
@@ -520,20 +522,9 @@ exports['auto removeListener has side effect on loop iterator'] = function(test)
 
 // Issue 410 on github: https://github.com/caolan/async/issues/410
 exports['auto calls callback multiple times'] = function(test) {
-    if (typeof process === 'undefined') {
-        // node only test
-        test.done();
-        return;
-    }
     var finalCallCount = 0;
-    var domain = require('domain').create();
-    domain.on('error', function (e) {
-        // ignore test error
-        if (!e._test_error) {
-            return test.done(e);
-        }
-    });
-    domain.run(function () {
+    // this will actually be synchronous, we can use try/catch
+    try {
         async.auto({
             task1: function(callback) { callback(null); },
             task2: ['task1', function(callback) { callback(null); }]
@@ -546,7 +537,12 @@ exports['auto calls callback multiple times'] = function(test) {
             e._test_error = true;
             throw e;
         });
-    });
+    } catch (e) {
+        // ignore test error
+        if (!e._test_error) {
+            return test.done(e);
+        }
+    }
     setTimeout(function () {
         test.equal(finalCallCount, 1,
             "Final auto callback should only be called once"
@@ -574,8 +570,10 @@ exports['auto modifying results causes final callback to run early'] = function(
         }
     },
     function(err, results){
+        debugger;
         test.equal(results.inserted, true)
-        test.ok(results.task3, 'task3')
+        test.ok(results.task2, 'task2 should be called')
+        test.ok(results.task3, 'task3 should be called')
         test.done();
     });
 };


### PR DESCRIPTION
From the discussion in #696 , this PR removes most internal `setImmediates` to remove the unnecessary performance hit when you're using asynchronous functions.  It leaves it to the user to guard against stack overflows with `async.setImmediate` or `async.nextTick` if they need to callback synchronously.  This is a **breaking change** since there are many people relying on automatic deferral in `waterfall` and `auto`.

I had to refactor the logic in the functions that used `setImmediate` because the internal logic was relying on those deferrals.  The timing of certain callbacks and events has also changed, so there will be further subtle breaking changes there.  If the functions you pass to async were actually asynchronous, things should work as they always have.

I left the deferrals in for `priorityQueue` and `cargo`, because those seemed to be needed for them to actually work.  They need to defer in order to become saturated so the priorities and payload sizes can take effect.

I also see that `queue`, `priorityQueue`, and `cargo` could likely be refactored to use the same underlying logic, albeit a bit more complicated. `queue` would have a payload size as well as a concurrency, and `q.push` would have an optional priority parameter.

