### PR TITLE
Add try-catch on every user iterator, task, etc.

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -119,7 +119,11 @@
         }
         var completed = 0;
         _each(arr, function (x) {
-            iterator(x, only_once(done) );
+            try {
+                iterator(x, only_once(done) );
+            } catch (error) {
+                done(error);
+            }
         });
         function done(err) {
           if (err) {
@@ -143,7 +147,7 @@
         }
         var completed = 0;
         var iterate = function () {
-            iterator(arr[completed], function (err) {
+            function done(err) {
                 if (err) {
                     callback(err);
                     callback = function () {};
@@ -157,7 +161,13 @@
                         iterate();
                     }
                 }
-            });
+            }
+
+            try {
+                iterator(arr[completed], done);
+            } catch (error) {
+                done(error);
+            }
         };
         iterate();
     };
@@ -165,7 +175,11 @@
 
     async.eachLimit = function (arr, limit, iterator, callback) {
         var fn = _eachLimit(limit);
-        fn.apply(null, [arr, iterator, callback]);
+        try {
+            fn.apply(null, [arr, iterator, callback]);
+        } catch (error) {
+            callback(error);
+        }
     };
     async.forEachLimit = async.eachLimit;
 
@@ -243,10 +257,16 @@
         } else {
             var results = [];
             eachfn(arr, function (x, callback) {
-                iterator(x.value, function (err, v) {
+                function done(err, v) {
                     results[x.index] = v;
                     callback(err);
-                });
+                }
+
+                try {
+                    iterator(x.value, done);
+                } catch (error) {
+                    done(error);
+                }
             }, function (err) {
                 callback(err, results);
             });
@@ -551,7 +571,11 @@
                         args.push(callback);
                     }
                     async.setImmediate(function () {
-                        iterator.apply(null, args);
+                        try {
+                            iterator.apply(null, args);
+                        } catch (error) {
+                            callback( error );
+                        }
                     });
                 }
             };
@@ -671,13 +695,26 @@
     async.concatSeries = doSeries(_concat);
 
     async.whilst = function (test, iterator, callback) {
-        if (test()) {
-            iterator(function (err) {
+        var result;
+        try {
+            result = test();
+        } catch (error) {
+            return callback(error);
+        }
+
+        if (result) {
+            function done(err) {
                 if (err) {
                     return callback(err);
                 }
                 async.whilst(test, iterator, callback);
-            });
+            }
+
+            try {
+                iterator(done);
+            } catch (error) {
+                done(error);
+            }
         }
         else {
             callback();
@@ -685,7 +722,7 @@
     };
 
     async.doWhilst = function (iterator, test, callback) {
-        iterator(function (err) {
+        function done(err) {
             if (err) {
                 return callback(err);
             }
@@ -696,17 +733,36 @@
             else {
                 callback();
             }
-        });
+        }
+
+        try {
+            iterator(done);
+        } catch (error) {
+            done(error);
+        }
     };
 
     async.until = function (test, iterator, callback) {
-        if (!test()) {
-            iterator(function (err) {
+        var result;
+        try {
+            result = test();
+        } catch (error) {
+            return callback(error);
+        }
+
+        if (!result) {
+            function done(err) {
                 if (err) {
                     return callback(err);
                 }
                 async.until(test, iterator, callback);
-            });
+            }
+
+            try {
+                iterator(done);
+            } catch (error) {
+                done(error);
+            }
         }
         else {
             callback();
@@ -714,18 +770,32 @@
     };
 
     async.doUntil = function (iterator, test, callback) {
-        iterator(function (err) {
+        function done(err) {
             if (err) {
                 return callback(err);
             }
             var args = Array.prototype.slice.call(arguments, 1);
-            if (!test.apply(null, args)) {
+
+            var result;
+            try {
+                result = test.apply(null, args);
+            } catch (error) {
+                return callback(error);
+            }
+
+            if (!result) {
                 async.doUntil(iterator, test, callback);
             }
             else {
                 callback();
             }
-        });
+        }
+
+        try {
+            iterator(done);
+        } catch (error) {
+            done(error);
+        }
     };
 
     async.queue = function (worker, concurrency) {
@@ -1100,7 +1170,11 @@
                 }
                 throw err;
             }
-            fn(next);
+            try {
+                fn(next);
+            } catch (error) {
+                callback(error);
+            }
         }
         next();
     };


### PR DESCRIPTION
Hi there,

You must be hearing this a lot but I really enjoy working with this great lib for a long time and I'm happy there are great guys like you to built it.

In this singe commit I put a try-catch on every user function that can throw and send the caught error to the callback function.
This will make the async lib much safer and predictable for users.

All tests are passing, hope you enjoy it.