### PR TITLE
Added settle function

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Usage:
 * [`series`](#seriestasks-callback)
 * [`parallel`](#parallel)
 * [`parallelLimit`](#parallellimittasks-limit-callback)
+* [`settle`](#settle)
 * [`whilst`](#whilst)
 * [`doWhilst`](#doWhilst)
 * [`until`](#until)
@@ -811,6 +812,68 @@ __Arguments__
   have completed. This function gets a results array (or object) containing all 
   the result arguments passed to the `task` callbacks.
 
+---------------------------------------
+
+<a name="settle" />
+### settle(tasks, [callback])
+
+Similar to [`parallel`](#parallel) only all `tasks` are allowed to finish executing before `callback` is executed. Once all tasks have completed, a results array is passed to the `callback` with `err` and `results` fields depending on the status of each individual task.
+
+Similar to parallel, `tasks` can be an array or an object. Results will be returned to the `callback` an object with each functions result object mapped to the functions original key in `tasks`.
+
+This function is primarily to be used in scenarios where logic dictates that all tasks should conclude execution even in the event that a subset fails so that the success/failure of each task can be handled individually.
+
+__Arguments__
+
+* `tasks` - An array or object containing functions to run, each function is passed
+a `callback(err, result...)` it must call on completion with an error `err` (which can  be `null`) and an optional `result` value(s).
+* `callback(results)` - An optional callback to run once all the functions have completed. This function gets a results array (or object) containing all the results in the format ```
+{
+    err: false,
+    results: [results]
+}
+``` in the case of a successful execution and ```{ err: _errObj_, results: undefined }``` in the case of an error.
+
+__Example__
+
+```js
+async.settle([
+    function(callback){
+        callback(undefined, { aVar: 'one' });
+    },
+    function(callback){
+        setTimeout(function(){
+            callback('some_error');
+        }, 100);
+    }
+],
+function(results) {
+    // The results will equal
+    // [
+    //   { err: false, results: { aVar: 'one' } },
+    //   { err: 'some_err', results: undefined }
+    // ]
+});
+
+// Using an object instead of an array
+async.settle({
+    one: function(callback){
+        callback(undefined, { aVar: 'one' });
+    },
+    two: function(callback){
+        setTimeout(function(){
+            callback('some_error');
+        }, 100);
+    }
+},
+function(results) {
+    // The results will equal
+    // {
+    //   one: { err: false, results: { aVar: 'one' } },
+    //   two: { err: 'some_err', results: undefined }
+    // }
+});
+```
 ---------------------------------------
 
 <a name="whilst" />

--- a/lib/async.js
+++ b/lib/async.js
@@ -599,6 +599,33 @@
         _parallel({ map: _mapLimit(limit), each: _eachLimit(limit) }, tasks, callback);
     };
 
+    async.settle = function (tasks, callback) {
+        callback = callback || function () {};
+        if (_isArray(tasks)) {
+            async.map(tasks, function (fn, callback) {
+                fn(function () {
+                    var args = Array.prototype.slice.call(arguments, 1);
+                    callback(undefined, {
+                        err: arguments[0] || false,
+                        results: args.length > 0 ? args : undefined
+                    });
+                });
+            }, function () { callback(arguments[1]) });
+        } else {
+            var results = {};
+            async.each(_keys(tasks), function (k, callback) {
+                tasks[k](function () {
+                    var args = Array.prototype.slice.call(arguments, 1);
+                    results[k] = {
+                        err: arguments[0] || false,
+                        results: args.length > 0 ? args : undefined
+                    };
+                    callback();
+                });
+            }, function () { callback(results); });
+        }
+    };
+
     async.series = function (tasks, callback) {
         callback = callback || function () {};
         if (_isArray(tasks)) {

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -955,6 +955,86 @@ exports['parallel call in another context'] = function(test) {
     vm.runInNewContext(fn, sandbox);
 };
 
+exports['settle object'] = function (test) {
+    var callOrder = [];
+    var finishOrder = [];
+    async.settle({
+        one: function (callback) {
+            callOrder.push(1);
+            setTimeout(function () {
+                finishOrder.push(1);
+                callback(undefined, 1, 2);
+            }, 10)
+        },
+        two: function (callback) {
+            callOrder.push(2);
+            setTimeout(function () {
+                finishOrder.push(2);
+                callback('errTwo');
+            }, 30)
+        },
+        three: function (callback) {
+            callOrder.push(3);
+            setTimeout(function () {
+                finishOrder.push(3);
+                callback(undefined, 3);
+            }, 20)
+        }
+    }, function (results) {
+        test.deepEqual(results, {
+            one: { err: false, results: [1, 2] },
+            two: { err: 'errTwo', results: undefined },
+            three: { err: false, results: [3] }
+        });
+        test.same(callOrder, [1,2,3]);
+        test.same(finishOrder, [1,3,2]);
+        test.done();
+    });
+};
+
+exports['settle array'] = function (test) {
+    var callOrder = [];
+    var finishOrder = [];
+    async.settle([
+        function fn1 (callback) {
+            callOrder.push(1);
+            setTimeout(function () {
+                finishOrder.push(1);
+                callback(undefined, 1, 2);
+            }, 10)
+        },
+        function fn2 (callback) {
+            callOrder.push(2);
+            setTimeout(function () {
+                finishOrder.push(2);
+                callback('errTwo');
+            }, 30)
+        },
+        function fn3 (callback) {
+            callOrder.push(3);
+            setTimeout(function () {
+                finishOrder.push(3);
+                callback(undefined, 3);
+            }, 20)
+        }
+    ], function (results) {
+        test.deepEqual(results, [
+            { err: false, results: [1, 2] },
+            { err: 'errTwo', results: undefined },
+            { err: false, results: [3] }
+        ]);
+        test.same(callOrder, [1,2,3]);
+        test.same(finishOrder, [1,3,2]);
+        test.done();
+    });
+};
+
+exports['settle empty array'] = function (test) {
+    async.settle([], function (results) {
+        test.same(results, []);
+        test.done();
+    });
+};
 
 exports['series'] = function(test){
     var call_order = [];


### PR DESCRIPTION
Added a 'settle' function that will allow all tasks to finish executing (in parallel) and then callback to the user. 

The goal of this function is to solve for when the user wants to execute tasks in parallel and wants them all to finish executing and return errors or results so that the handler can handle errors on a per task basis AND know what the return of the successful tasks was. With parallel, I can get an error and the results of any tasks finished at the time of error, but I'm unsure of the state of any tasks not complete at time of error. 