### PR TITLE
Wrap makefile directory strings in quotes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PACKAGE = asyncjs
 NODEJS = $(if $(shell test -f /usr/bin/nodejs && echo "true"),nodejs,node)
-CWD := $(shell pwd)
+CWD := "$(shell pwd)"
 NODEUNIT = $(CWD)/node_modules/nodeunit/bin/nodeunit
 UGLIFY = $(CWD)/node_modules/uglify-js/bin/uglifyjs
 NODELINT = $(CWD)/node_modules/nodelint/nodelint


### PR DESCRIPTION
Basically, the make tasks break if your current working directory contains spaces. This PR wraps the cwd in quotes so that doesn't happen.