### PR TITLE
Adding an error function called when a worker encounters an error

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -769,10 +769,12 @@
         var workers = 0;
         var q = {
             tasks: [],
+            errors: [],
             concurrency: concurrency,
             saturated: null,
             empty: null,
             drain: null,
+            error: null,
             started: false,
             paused: false,
             push: function (data, callback) {
@@ -794,6 +796,9 @@
                     workers += 1;
                     var next = function () {
                         workers -= 1;
+                        if (q.error && arguments[0]) {
+                            q.error(arguments[0]);
+                        }
                         if (task.callback) {
                             task.callback.apply(task, arguments);
                         }
@@ -827,7 +832,7 @@
                 for (var w = 1; w <= q.concurrency; w++) {
                     async.setImmediate(q.process);
                 }
-            }
+            },
         };
         return q;
     };

--- a/lib/async.js
+++ b/lib/async.js
@@ -769,7 +769,6 @@
         var workers = 0;
         var q = {
             tasks: [],
-            errors: [],
             concurrency: concurrency,
             saturated: null,
             empty: null,
@@ -832,7 +831,7 @@
                 for (var w = 1; w <= q.concurrency; w++) {
                     async.setImmediate(q.process);
                 }
-            },
+            }
         };
         return q;
     };


### PR DESCRIPTION
I'm using async.queue to recursively crawl folders on a distant API. 
The workers can push new tasks to the queue.

For my use case, the simplest and cleanest way to handle/log errors without stoping the async execution (When the API fails to respond for example) is  to call an error handling function set up the same way of drain();

````
q.taskQueue.error = function(err) {
      console.log(err);
  };
````

You can then handle the error the way you wish.