### PR TITLE
Add cargo animation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1154,7 +1154,7 @@ Creates a `cargo` object with the specified payload. Tasks added to the
 cargo will be processed altogether (up to the `payload` limit). If the
 `worker` is in progress, the task is queued until it becomes available. Once
 the `worker` has completed some tasks, each callback of those tasks is called.
-Check out [this animation](https://camo.githubusercontent.com/6bbd36f4cf5b35a0f11a96dcd2e97711ffc2fb37/68747470733a2f2f662e636c6f75642e6769746875622e636f6d2f6173736574732f313637363837312f36383130382f62626330636662302d356632392d313165322d393734662d3333393763363464633835382e676966) for how `cargo` and `queue` work.
+Check out [these](https://camo.githubusercontent.com/6bbd36f4cf5b35a0f11a96dcd2e97711ffc2fb37/68747470733a2f2f662e636c6f75642e6769746875622e636f6d2f6173736574732f313637363837312f36383130382f62626330636662302d356632392d313165322d393734662d3333393763363464633835382e676966) [animations](https://camo.githubusercontent.com/f4810e00e1c5f5f8addbe3e9f49064fd5d102699/68747470733a2f2f662e636c6f75642e6769746875622e636f6d2f6173736574732f313637363837312f36383130312f38346339323036362d356632392d313165322d383134662d3964336430323431336266642e676966) for how `cargo` and `queue` work.
 
 While [queue](#queue) passes only one task to one of a group of workers
 at a time, cargo passes an array of tasks to a single worker, repeating


### PR DESCRIPTION
For some reason the README only included one of @rhyzx 's brilliant animations, which really help explain `cargo`