### PR TITLE
Add code coverage via istanbul and coveralls.io

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+repo_token: z3N5AJtMkYvAS9dsQlpUiBAxV9VI8ZRq7

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
   - "0.10"
   - "0.11"
+script: "npm run coveralls"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Async.js
 
 [![Build Status via Travis CI](https://travis-ci.org/caolan/async.svg?branch=master)](https://travis-ci.org/caolan/async)
-
+[![Coverage Status](https://coveralls.io/repos/justincy/async/badge.svg?branch=coverage)](https://coveralls.io/r/justincy/async?branch=coverage)
 
 Async is a utility module which provides straight-forward, powerful functions
 for working with asynchronous JavaScript. Although originally designed for

--- a/package.json
+++ b/package.json
@@ -22,10 +22,12 @@
     "url": "https://github.com/caolan/async/raw/master/LICENSE"
   },
   "devDependencies": {
-    "nodeunit": ">0.0.0",
-    "uglify-js": "1.2.x",
+    "coveralls": "^2.11.2",
+    "istanbul": "^0.3.13",
+    "lodash": ">=2.4.1",
     "nodelint": ">0.0.0",
-    "lodash": ">=2.4.1"
+    "nodeunit": ">0.0.0",
+    "uglify-js": "1.2.x"
   },
   "jam": {
     "main": "lib/async.js",
@@ -39,7 +41,9 @@
     ]
   },
   "scripts": {
-    "test": "nodeunit test/test-async.js"
+    "test": "nodeunit test/test-async.js",
+    "coverage": "istanbul cover ./node_modules/nodeunit/bin/nodeunit -- test/test-async.js",
+    "coveralls": "istanbul cover ./node_modules/nodeunit/bin/nodeunit -- test/test-async.js && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage"
   },
   "spm": {
     "main": "lib/async.js"


### PR DESCRIPTION
Two new npm run commands:

* `coverage` - runs coverage and produces an html report in the coverage directory.
* `coveralls` - runs coverage and sends information to [coveralls.io](https://coveralls.io/)

I modifed `.travis.yml` to have run `npm run coveralls` which runs the tests and updates coverage in coveralls.

If you accept this then you would want to change the repo token in `.coveralls.yml` and update the badge URL.

FYI, [current coverage](https://coveralls.io/r/justincy/async) is 93%.