### PR TITLE
callbackNextTick method added to API

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -656,6 +656,13 @@
         };
     };
 
+    async.callbackNextTick = function (fn) {
+        var args = Array.prototype.slice.call(arguments, 1);
+        return async.nextTick(function () {
+            return fn.apply(null, args);
+        });
+    };
+
     var _concat = function (eachfn, arr, fn, callback) {
         var r = [];
         eachfn(arr, function (x, cb) {


### PR DESCRIPTION
Sometimes an async function needs tor return  a sync result. For the sake of consistency of async flow; we need to call the callback function wrapped in a nextTick block. This new method simplifys this effort.

Example:
```js
function asyncFn (other_arguments, callback) {
  if (cached_result) {
    return async.callbackNextTick(callback, cached_result);
  }
  some_async_call(some_arguments, callback);
}
```