### PR TITLE
added blocking parameter to priorityQueue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1137,13 +1137,36 @@ q.unshift({name: 'bar'}, function (err) {
 ---------------------------------------
 
 <a name="priorityQueue" />
-### priorityQueue(worker, concurrency)
+### priorityQueue(worker, concurrency, blocking)
 
-The same as [`queue`](#queue) only tasks are assigned a priority and completed in ascending priority order. There are two differences between `queue` and `priorityQueue` objects:
+The same as [`queue`](#queue) only tasks are assigned a priority and completed in ascending priority order. If `concurrency > 1` and `blocking` is `true`, the process will wait until all the tasks with the current priority are over before starting tasks with a lower priority (higher value), even with available workers.
+There are two differences between `queue` and `priorityQueue` objects:
 
 * `push(task, priority, [callback])` - `priority` should be a number. If an array of
   `tasks` is given, all tasks will be assigned the same priority.
 * The `unshift` method was removed.
+
+__Example__
+
+```js
+var q = async.priorityQueue(function (task, callback) {
+    setTimeout(function(){
+      console.log('hello ' + task.name)
+      callback();
+    }, task.delay);
+}, 2, true);
+
+// add some items to the queue
+
+q.push({name: 'foo', delay: 100}, 1, function (err) {
+    console.log('finished processing foo');
+});
+q.push({name: 'bar', delay: 50}, 2, function (err) {
+    console.log('finished processing bar');
+});
+```
+
+With `blocking` set to `false`, the output order will be `bar` then `foo`, while if `blocking` is set to`true`, it'll be `foo` and then `bar`, even if `bar` task is shorter than `foo` and `concurrency` is set to 2.
 
 ---------------------------------------
 

--- a/lib/async.js
+++ b/lib/async.js
@@ -832,7 +832,8 @@
         return q;
     };
 
-    async.priorityQueue = function (worker, concurrency) {
+    async.priorityQueue = function (worker, concurrency, blocking) {
+        var blocking = blocking || false;
 
         function _compareTasks(a, b){
           return a.priority - b.priority;
@@ -884,12 +885,47 @@
         }
 
         // Start with a normal queue
+        var workers = 0;
+        var currentPriority = null;
         var q = async.queue(worker, concurrency);
 
         // Override push to accept second parameter representing priority
         q.push = function (data, priority, callback) {
           _insert(q, data, priority, callback);
         };
+
+        if (blocking){
+            q.process = function () {
+                if (currentPriority === null){
+                    currentPriority = q.tasks[0].priority;
+                }
+
+                if (!q.paused && workers < q.concurrency && q.tasks.length && q.tasks[0].priority == currentPriority) {
+                    var task = q.tasks.shift();
+                    if (q.empty && q.tasks.length === 0) {
+                        q.empty();
+                    }
+
+                    workers += 1;
+                    var next = function () {
+                        workers -= 1;
+                        if (q.tasks.length && q.tasks[0].priority > currentPriority){
+                            currentPriority = q.tasks[0].priority;
+                        }
+                        if (task.callback) {
+                            task.callback.apply(task, arguments);
+                        }
+                        if (q.drain && q.tasks.length + workers === 0) {
+                            q.drain();
+                        }
+                        q.process();
+                    };
+                    var cb = only_once(next);
+                    worker(task.data, cb);
+
+                }
+            };
+        }
 
         // Remove unshift function
         delete q.unshift;


### PR DESCRIPTION
I needed a priorityQuery with the ability to
1. process tasks concurrently
2. wait before processing lower priority tasks until those with higher priority are over, even with free workers 

Real (trivial) use case: in my list of tasks, I have an higher priority task (foo) that lasts longer than a lower priority task (bar), the concurrency is set to 2. I'd like to have them executed in the same priority order, so that bar doesn't start until foo is completed.