### PR TITLE
perf(slice): fix not to use `Array#slice`

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -97,6 +97,23 @@
         return keys;
     };
 
+    var _baseSlice = function (arr, start) {
+        start = start || 0;
+        var index = -1;
+        var length = arr.length;
+
+        if (start) {
+          length -= start;
+          length = length < 0 ? 0 : length;
+        }
+        var result = Array(length);
+
+        while (++index < length) {
+          result[index] = arr[index + start];
+        }
+        return result;
+    };
+
     //// exported async module functions ////
 
     //// nextTick implementation with browser-compatible fallback ////
@@ -338,19 +355,19 @@
 
     var doParallel = function (fn) {
         return function () {
-            var args = Array.prototype.slice.call(arguments);
+            var args = _baseSlice(arguments);
             return fn.apply(null, [async.each].concat(args));
         };
     };
     var doParallelLimit = function(limit, fn) {
         return function () {
-            var args = Array.prototype.slice.call(arguments);
+            var args = _baseSlice(arguments);
             return fn.apply(null, [_eachLimit(limit)].concat(args));
         };
     };
     var doSeries = function (fn) {
         return function () {
-            var args = Array.prototype.slice.call(arguments);
+            var args = _baseSlice(arguments);
             return fn.apply(null, [async.eachSeries].concat(args));
         };
     };
@@ -581,7 +598,7 @@
         _each(keys, function (k) {
             var task = _isArray(tasks[k]) ? tasks[k]: [tasks[k]];
             var taskCallback = function (err) {
-                var args = Array.prototype.slice.call(arguments, 1);
+                var args = _baseSlice(arguments, 1);
                 if (args.length <= 1) {
                     args = args[0];
                 }
@@ -679,7 +696,7 @@
                     callback = noop;
                 }
                 else {
-                    var args = Array.prototype.slice.call(arguments, 1);
+                    var args = _baseSlice(arguments, 1);
                     var next = iterator.next();
                     if (next) {
                         args.push(wrapIterator(next));
@@ -702,7 +719,7 @@
             eachfn.map(tasks, function (fn, callback) {
                 if (fn) {
                     fn(function (err) {
-                        var args = Array.prototype.slice.call(arguments, 1);
+                        var args = _baseSlice(arguments, 1);
                         if (args.length <= 1) {
                             args = args[0];
                         }
@@ -715,7 +732,7 @@
             var results = {};
             eachfn.each(_keys(tasks), function (k, callback) {
                 tasks[k](function (err) {
-                    var args = Array.prototype.slice.call(arguments, 1);
+                    var args = _baseSlice(arguments, 1);
                     if (args.length <= 1) {
                         args = args[0];
                     }
@@ -742,7 +759,7 @@
             async.mapSeries(tasks, function (fn, callback) {
                 if (fn) {
                     fn(function (err) {
-                        var args = Array.prototype.slice.call(arguments, 1);
+                        var args = _baseSlice(arguments, 1);
                         if (args.length <= 1) {
                             args = args[0];
                         }
@@ -755,7 +772,7 @@
             var results = {};
             async.eachSeries(_keys(tasks), function (k, callback) {
                 tasks[k](function (err) {
-                    var args = Array.prototype.slice.call(arguments, 1);
+                    var args = _baseSlice(arguments, 1);
                     if (args.length <= 1) {
                         args = args[0];
                     }
@@ -785,10 +802,10 @@
     };
 
     async.apply = function (fn) {
-        var args = Array.prototype.slice.call(arguments, 1);
+        var args = _baseSlice(arguments, 1);
         return function () {
             return fn.apply(
-                null, args.concat(Array.prototype.slice.call(arguments))
+                null, args.concat(_baseSlice(arguments))
             );
         };
     };
@@ -826,7 +843,7 @@
             if (err) {
                 return callback(err);
             }
-            var args = Array.prototype.slice.call(arguments, 1);
+            var args = _baseSlice(arguments, 1);
             if (test.apply(null, args)) {
                 async.doWhilst(iterator, test, callback);
             }
@@ -855,7 +872,7 @@
             if (err) {
                 return callback(err);
             }
-            var args = Array.prototype.slice.call(arguments, 1);
+            var args = _baseSlice(arguments, 1);
             if (!test.apply(null, args)) {
                 async.doUntil(iterator, test, callback);
             }
@@ -1104,9 +1121,9 @@
 
     var _console_fn = function (name) {
         return function (fn) {
-            var args = Array.prototype.slice.call(arguments, 1);
+            var args = _baseSlice(arguments, 1);
             fn.apply(null, args.concat([function (err) {
-                var args = Array.prototype.slice.call(arguments, 1);
+                var args = _baseSlice(arguments, 1);
                 if (typeof console !== 'undefined') {
                     if (err) {
                         if (console.error) {
@@ -1135,7 +1152,7 @@
             return x;
         };
         var memoized = function () {
-            var args = Array.prototype.slice.call(arguments);
+            var args = _baseSlice(arguments);
             var callback = args.pop();
             var key = hasher.apply(null, args);
             if (key in memo) {
@@ -1149,7 +1166,7 @@
             else {
                 queues[key] = [callback];
                 fn.apply(null, args.concat([function () {
-                    memo[key] = arguments;
+                    memo[key] = _baseSlice(arguments);
                     var q = queues[key];
                     delete queues[key];
                     for (var i = 0, l = q.length; i < l; i++) {
@@ -1189,12 +1206,12 @@
         var fns = arguments;
         return function () {
             var that = this;
-            var args = Array.prototype.slice.call(arguments);
+            var args = _baseSlice(arguments);
             var callback = args.pop();
             async.reduce(fns, args, function (newargs, fn, cb) {
                 fn.apply(that, newargs.concat([function () {
                     var err = arguments[0];
-                    var nextargs = Array.prototype.slice.call(arguments, 1);
+                    var nextargs = _baseSlice(arguments, 1);
                     cb(err, nextargs);
                 }]));
             },
@@ -1211,7 +1228,7 @@
     var _applyEach = function (eachfn, fns /*args...*/) {
         var go = function () {
             var that = this;
-            var args = Array.prototype.slice.call(arguments);
+            var args = _baseSlice(arguments);
             var callback = args.pop();
             return eachfn(fns, function (fn, cb) {
                 fn.apply(that, args.concat([cb]));
@@ -1219,7 +1236,7 @@
             callback);
         };
         if (arguments.length > 2) {
-            var args = Array.prototype.slice.call(arguments, 2);
+            var args = _baseSlice(arguments, 2);
             return go.apply(this, args);
         }
         else {


### PR DESCRIPTION
I fixed not to use `Array.prototype.slice.call(arguments)`.
This `_baseSlice` is based on [lodash](https://github.com/lodash/lodash/blob/master/lodash.src.js#L2711-L2731).

- [improve performance](https://github.com/suguru03/neo-async/commit/be3997f2c94baa82b1f839c4e25a0c60c5103f91)
- [Optimiztion-killers#leaking-arguments](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#32-leaking-arguments)