### PR TITLE
Implement contextSeries - alternative to waterfall

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -661,6 +661,35 @@
         wrapIterator(async.iterator(tasks))();
     };
 
+    async.contextSeries = function(tasks, callback) {
+        callback = _once(callback || noop);
+        if (!_isArray(tasks)) {
+            return callback(new Error('First argument to contextSeries must be an array'));
+        }
+
+        var currentDependencies = [];
+        var autoGraph = {};
+        _arrayEach(tasks, function(task, index) {
+            var taskName, taskFn;
+            if (_isArray(task)) {
+                taskName = task[0];
+                taskFn = task[1];
+            } else {
+                taskName = "$"+index;
+                taskFn = task;
+            }
+
+            autoGraph[taskName] = function(callback, currentResults) {
+                taskFn(currentResults, callback);
+            };
+            if (currentDependencies.length) {
+                autoGraph[taskName] = currentDependencies.concat(autoGraph[taskName]);
+            }
+            currentDependencies.push(taskName);
+        });
+        async.auto(autoGraph, callback);
+    };
+
     function _parallel(eachfn, tasks, callback) {
         callback = callback || noop;
         var results = _isArrayLike(tasks) ? [] : {};

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -897,6 +897,34 @@ exports['waterfall'] = {
 
 };
 
+exports['contextSeries'] = function(test) {
+    var tasks = [
+        [
+            't1', function(r, cb) {
+                test.same(r, {});
+                cb(null, 'v1');
+            }
+        ],
+        [
+            't2', function(r, cb) {
+                test.same(r, {'t1': 'v1'});
+                setTimeout(function() {
+                    cb(null, 'v2');
+                }, 25);
+            }
+        ],
+        function(r, cb) {
+            test.same(r, {'t1': 'v1', 't2': 'v2'});
+            cb(null, 'last');
+        }
+    ];
+    async.contextSeries(tasks, function(err, results) {
+        test.ok(err === null, err + " passed instead of 'null'");
+        test.same(results, {'t1': 'v1', 't2': 'v2', '$2': 'last'});
+        test.done();
+    });
+};
+
 exports['parallel'] = function(test){
     var call_order = [];
     async.parallel([


### PR DESCRIPTION
This function is mainly useful as an alternative to watefall in versions of javascript, which support destructing.

Main problem with waterfall is that it becomes hard to debug/refactor after initial write due to needing to passaround arguments in _exactly_ the correct order. This function when used with destructing gets around that problem by allowing to name steps in the series and then each function can grab results it cares about.

Example (in coffeescript):
```coffeescript
# Adapted from one of my work scripts

getCurrentShards = (r, callback) -> # ...
cleanupOldShardMoves = ({shardInfo}, callback) -> # ...
createTask = ({shardInfo}, callback) -> # ...
setMoveStatus = (newStatus, {taskId, state}, callback) -> # ...
lockShards = ({taskId, shardInfo}, callback) -> # ...
# etc...

tasks = [
  ['shardInfo', getCurrentShards]
  cleanupOldShardMoves
  ['taskId', createTask]
  ['state', _.partial(setMoveStatus, 'initial')]
  lockShards
  _.partial(setMoveStatus, 'moving')
  moveInBatches
  _.partial(setMoveStatus, 'unlocking')
  unlockShards
  ['timestamp', updateMetadata]
]
async.contextSeries tasks, (err, {timestamp, taskId}) ->
  # ...
  log.info "Shard moves completed successfully at #{format timestamp} for task #{taskId}"

```

This function can prove to be even more useful by adding an optional `seedData` object with values which are made available to each task in the contextSeries array. I have omitted that however due to it not really fitting in with the rest of the API.