### PR TITLE
Wrap seq arguments doc in backticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1099,7 +1099,7 @@ Each function is executed with the `this` binding of the composed function.
 
 __Arguments__
 
-* functions... - the asynchronous functions to compose
+* `functions...` - the asynchronous functions to compose
 
 
 __Example__


### PR DESCRIPTION
This change wraps `seq(fn1, fn2...)`'s arguments doc in backticks to match the rest of the doc.