### PR TITLE
Improve the detection of global/root object

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -20,6 +20,7 @@
     "browser": true,
     "node": true,
     "globals": {
+        "self": true,
         "define": true
     }
 }

--- a/lib/async.js
+++ b/lib/async.js
@@ -11,17 +11,14 @@
     function noop() {}
 
     // global on the server, window in the browser
-    var root, previous_async;
+    var previous_async;
 
-    if (typeof window == 'object' && this === window) {
-        root = window;
-    }
-    else if (typeof global == 'object' && this === global) {
-        root = global;
-    }
-    else {
-        root = this;
-    }
+    // Establish the root object, `window` (`self`) in the browser, `global`
+    // on the server, or `this` in some virtual machines. We use `self`
+    // instead of `window` for `WebWorker` support.
+    var root = typeof self === 'object' && self.self === self && self ||
+            typeof global === 'object' && global.global === global && global ||
+            this;
 
     if (root != null) {
         previous_async = root.async;


### PR DESCRIPTION
Refer to https://github.com/jashkenas/underscore/issues/2152. We were using a similar approach to `async`s current one in underscore until https://github.com/jashkenas/underscore/pull/2153.

The two main benefits of this change are:
 - Forwards compatibility with `strict` mode and some tooling (see https://github.com/jashkenas/underscore/issues/2152)
 - `WebWorker` support, you can't use `window` in a `WebWorker` but you can use `self`

Aside: [here's the detection method from lodash](https://github.com/lodash/lodash/blob/master/lodash.js#L248-254)