### PR TITLE
Add someLimit and everyLimit

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,11 @@ Some functions are also available in the following forms:
 * [`reduce`](#reduce), [`reduceRight`](#reduceRight)
 * [`detect`](#detect), `detectSeries`
 * [`sortBy`](#sortBy)
-* [`some`](#some), [`every`](#every)
-* [`concat`](#concat), `concatSeries`
+* [`some`](#some)
+* [`someLimit`](#someLimit)
+* [`every`](#every)
+* [`concat`](#concat)
+* [`concatSeries`](#concatSeries)
 
 ### Control Flow
 
@@ -578,6 +581,27 @@ async.some(['file1','file2','file3'], fs.exists, function(result){
     // if result is true then at least one of the files exists
 });
 ```
+
+---------------------------------------
+
+<a name="someLimit" />
+### someLimit(arr, limit iterator, callback)
+
+__Alias:__ `anyLimit`
+
+The same as [`some`](#some), only no more than `limit` `iterator`s will be simultaneously 
+running at any time.
+
+__Arguments__
+
+* `arr` - An array to iterate over.
+* `limit` - The maximum number of `iterator`s to run at any time.
+* `iterator(item, callback)` - A truth test to apply to each item in the array
+  in parallel. The iterator is passed a callback(truthValue) which must be 
+  called with a boolean argument once it has completed.
+* `callback(result)` - A callback which is called as soon as any iterator returns
+  `true`, or after all the iterator functions have finished. Result will be
+  either `true` or `false` depending on the values of the async tests.
 
 ---------------------------------------
 

--- a/lib/async.js
+++ b/lib/async.js
@@ -9,6 +9,12 @@
 
     var async = {};
     function noop() {}
+    function identity(v) {
+        return v;
+    }
+    function notId(v) {
+        return !v;
+    }
 
     // global on the server, window in the browser
     var previous_async;
@@ -449,35 +455,27 @@
     async.detect = doParallel(_detect);
     async.detectSeries = doSeries(_detect);
 
-    async.any =
-    async.some = function (arr, iterator, main_callback) {
-        async.eachOf(arr, function (x, _, callback) {
-            iterator(x, function (v) {
-                if (v) {
-                    main_callback(true);
-                    main_callback = noop;
-                }
-                callback();
+    function _createTester(eachfn, check, defaultValue) {
+        return function(arr, iterator, main_callback) {
+            eachfn(arr, function (x, _, callback) {
+                iterator(x, function (v) {
+                    if (check(v)) {
+                        main_callback(!defaultValue);
+                        main_callback = noop;
+                    }
+                    callback();
+                });
+            }, function () {
+                main_callback(defaultValue);
             });
-        }, function () {
-            main_callback(false);
-        });
-    };
+        };
+    }
+
+    async.any =
+    async.some = _createTester(async.eachOf, identity, false);
 
     async.all =
-    async.every = function (arr, iterator, main_callback) {
-        async.eachOf(arr, function (x, _, callback) {
-            iterator(x, function (v) {
-                if (!v) {
-                    main_callback(false);
-                    main_callback = noop;
-                }
-                callback();
-            });
-        }, function () {
-            main_callback(true);
-        });
-    };
+    async.every = _createTester(async.eachOf, notId, true);
 
     async.sortBy = function (arr, iterator, callback) {
         async.map(arr, function (x, callback) {

--- a/lib/async.js
+++ b/lib/async.js
@@ -487,6 +487,8 @@
     async.all =
     async.every = _createTester(async.eachOf, notId, true);
 
+    async.everyLimit = _createTester(async.eachOfLimit, notId, true);
+
     async.sortBy = function (arr, iterator, callback) {
         async.map(arr, function (x, callback) {
             iterator(x, function (err, criteria) {

--- a/lib/async.js
+++ b/lib/async.js
@@ -456,8 +456,11 @@
     async.detectSeries = doSeries(_detect);
 
     function _createTester(eachfn, check, defaultValue) {
-        return function(arr, iterator, main_callback) {
-            eachfn(arr, function (x, _, callback) {
+        return function(arr, limit, iterator, main_callback) {
+            function done() {
+                main_callback(defaultValue);
+            }
+            function iteratee(x, _, callback) {
                 iterator(x, function (v) {
                     if (check(v)) {
                         main_callback(!defaultValue);
@@ -465,14 +468,21 @@
                     }
                     callback();
                 });
-            }, function () {
-                main_callback(defaultValue);
-            });
+            }
+            if (arguments.length > 3) {
+                eachfn(arr, limit, iteratee, done);
+            } else {
+                main_callback = iterator;
+                iterator = limit;
+                eachfn(arr, iteratee, done);
+            }
         };
     }
 
     async.any =
     async.some = _createTester(async.eachOf, identity, false);
+
+    async.someLimit = _createTester(async.eachOfLimit, identity, false);
 
     async.all =
     async.every = _createTester(async.eachOf, notId, true);

--- a/lib/async.js
+++ b/lib/async.js
@@ -456,15 +456,16 @@
     async.detectSeries = doSeries(_detect);
 
     function _createTester(eachfn, check, defaultValue) {
-        return function(arr, limit, iterator, main_callback) {
+        return function(arr, limit, iterator, cb) {
             function done() {
-                main_callback(defaultValue);
+                if (cb) cb(defaultValue);
             }
             function iteratee(x, _, callback) {
+                if (!cb) return callback();
                 iterator(x, function (v) {
-                    if (check(v)) {
-                        main_callback(!defaultValue);
-                        main_callback = noop;
+                    if (cb && check(v)) {
+                        cb(!defaultValue);
+                        cb = false;
                     }
                     callback();
                 });
@@ -472,7 +473,7 @@
             if (arguments.length > 3) {
                 eachfn(arr, limit, iteratee, done);
             } else {
-                main_callback = iterator;
+                cb = iterator;
                 iterator = limit;
                 eachfn(arr, iteratee, done);
             }

--- a/lib/async.js
+++ b/lib/async.js
@@ -465,7 +465,7 @@
                 iterator(x, function (v) {
                     if (cb && check(v)) {
                         cb(!defaultValue);
-                        cb = false;
+                        cb = iterator = false;
                     }
                     callback();
                 });

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Higher-order functions and common patterns for asynchronous code",
   "main": "lib/async.js",
   "author": "Caolan McMahon",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "keywords": [
     "async",
     "callback",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Higher-order functions and common patterns for asynchronous code",
   "main": "lib/async.js",
   "author": "Caolan McMahon",
-  "version": "1.3.0",
+  "version": "1.2.1",
   "keywords": [
     "async",
     "callback",

--- a/perf/suites.js
+++ b/perf/suites.js
@@ -180,6 +180,66 @@ module.exports = [
     }
   },
   {
+    name: "some - no short circuit- false",
+    // args lists are passed to the setup function
+    args: [[500]],
+    setup: function(count) {
+      tasks = _.range(count);
+    },
+    fn: function (async, done) {
+      async.some(tasks, function(i, cb) {
+        async.setImmediate(function() {
+          cb(i >= 600);
+        });
+      }, done);
+    }
+  },
+  {
+    name: "some - short circuit - true",
+    // args lists are passed to the setup function
+    args: [[500]],
+    setup: function(count) {
+      tasks = _.range(count);
+    },
+    fn: function (async, done) {
+      async.some(tasks, function(i, cb) {
+        async.setImmediate(function() {
+          cb(i >= 60);
+        });
+      }, done);
+    }
+  },
+  {
+    name: "every - no short circuit- true",
+    // args lists are passed to the setup function
+    args: [[500]],
+    setup: function(count) {
+      tasks = _.range(count);
+    },
+    fn: function (async, done) {
+      async.every(tasks, function(i, cb) {
+        async.setImmediate(function() {
+          cb(i <= 600);
+        });
+      }, done);
+    }
+  },
+  {
+    name: "every - short circuit - false",
+    // args lists are passed to the setup function
+    args: [[500]],
+    setup: function(count) {
+      tasks = _.range(count);
+    },
+    fn: function (async, done) {
+      async.every(tasks, function(i, cb) {
+        async.setImmediate(function() {
+          cb(i <= 60);
+        });
+      }, done);
+    }
+  },
+  {
     name: "defer nextTick",
     fn: function (async, done) {
       process.nextTick(done);

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -2254,6 +2254,24 @@ exports['someLimit false'] = function(test){
     });
 };
 
+exports['every true'] = function(test){
+    async.everyLimit([3,1,2], 1, function(x, callback){
+        setTimeout(function(){callback(x > 1);}, 0);
+    }, function(result){
+        test.equals(result, true);
+        test.done();
+    });
+};
+
+exports['everyLimit false'] = function(test){
+    async.everyLimit([3,1,2], 2, function(x, callback){
+        setTimeout(function(){callback(x === 2);}, 0);
+    }, function(result){
+        test.equals(result, false);
+        test.done();
+    });
+};
+
 exports['any alias'] = function(test){
     test.equals(async.any, async.some);
     test.done();

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -2272,6 +2272,33 @@ exports['everyLimit false'] = function(test){
     });
 };
 
+exports['everyLimit short-circuit'] = function(test){
+    test.expect(2);
+    var calls = 0;
+    async.everyLimit([3,1,2], 1, function(x, callback){
+        calls++;
+        callback(x === 1);
+    }, function(result){
+        test.equals(result, false);
+        test.equals(calls, 1);
+        test.done();
+    });
+};
+
+
+exports['someLimit short-circuit'] = function(test){
+    test.expect(2);
+    var calls = 0;
+    async.someLimit([3,1,2], 1, function(x, callback){
+        calls++;
+        callback(x === 1);
+    }, function(result){
+        test.equals(result, true);
+        test.equals(calls, 2);
+        test.done();
+    });
+};
+
 exports['any alias'] = function(test){
     test.equals(async.any, async.some);
     test.done();

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -2236,6 +2236,24 @@ exports['some early return'] = function(test){
     }, 100);
 };
 
+exports['someLimit true'] = function(test){
+    async.someLimit([3,1,2], 2, function(x, callback){
+        setTimeout(function(){callback(x === 2);}, 0);
+    }, function(result){
+        test.equals(result, true);
+        test.done();
+    });
+};
+
+exports['someLimit false'] = function(test){
+    async.someLimit([3,1,2], 2, function(x, callback){
+        setTimeout(function(){callback(x === 10);}, 0);
+    }, function(result){
+        test.equals(result, false);
+        test.done();
+    });
+};
+
 exports['any alias'] = function(test){
     test.equals(async.any, async.some);
     test.done();


### PR DESCRIPTION
Merges the implementations of `some` and `every` and adds their respective limit functions (with partial short circuiting)

PS I think short circuiting should be done like lodash does it (allowing `each` to break):
  if `cb` resolves with `cb(false)` you break the loop (in lodash if you return false it breaks the loop)

Resolves #548 