### PR TITLE
asyncify promisified functions

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -1186,10 +1186,18 @@
             var result;
             try {
                 result = func.apply(this, args);
+                // if result is Promise object
+                if (typeof result.then === "function") {
+                    result.then(function(values) {
+                        var args = [null].concat(values);
+                        callback.apply(this, args);
+                    }).catch(callback);
+                } else {
+                    callback(null, result);
+                }
             } catch (e) {
                 return callback(e);
             }
-            callback(null, result);
         });
     };
 

--- a/lib/async.js
+++ b/lib/async.js
@@ -1186,17 +1186,18 @@
             var result;
             try {
                 result = func.apply(this, args);
-                // if result is Promise object
-                if (typeof result.then === "function") {
-                    result.then(function(values) {
-                        var args = [null].concat(values);
-                        callback.apply(this, args);
-                    }).catch(callback);
-                } else {
-                    callback(null, result);
-                }
             } catch (e) {
                 return callback(e);
+            }
+            // if result is Promise object
+            if (typeof result !== 'undefined' && typeof result.then === "function") {
+                result.then(function(value) {
+                    callback(null, value);
+                }).catch(function(err) {
+                    callback(new Error(err));
+                });
+            } else {
+                callback(null, result);
             }
         });
     };

--- a/lib/async.js
+++ b/lib/async.js
@@ -1194,7 +1194,7 @@
                 result.then(function(value) {
                     callback(null, value);
                 }).catch(function(err) {
-                    callback(new Error(err));
+                    callback(err.message ? err : new Error(err));
                 });
             } else {
                 callback(null, result);

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "jshint": "~2.8.0",
     "lodash": "^3.9.0",
     "mkdirp": "~0.5.1",
+    "native-promise-only": "^0.8.0-a",
     "nodeunit": ">0.0.0",
     "nyc": "^2.1.0",
     "rsvp": "^3.0.18",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,13 @@
   "devDependencies": {
     "benchmark": "bestiejs/benchmark.js",
     "coveralls": "^2.11.2",
+    "es6-promise": "^2.3.0",
     "jshint": "~2.8.0",
     "lodash": "^3.9.0",
     "mkdirp": "~0.5.1",
     "nodeunit": ">0.0.0",
     "nyc": "^2.1.0",
+    "rsvp": "^3.0.18",
     "uglify-js": "~2.4.0",
     "xyz": "^0.5.0",
     "yargs": "~3.9.1"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "benchmark": "bestiejs/benchmark.js",
+    "bluebird": "^2.9.32",
     "coveralls": "^2.11.2",
     "es6-promise": "^2.3.0",
     "jscs": "^1.13.1",

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -4269,6 +4269,39 @@ exports['asyncify'] = {
         }
     },
 
+    'bluebird': {
+        'setUp': function (callback) {
+            this.Promise = require('bluebird');
+            callback();
+        },
+
+        'resolve': function(test) {
+            var promisified = this.Promise.promisify(function(argument, callback) {
+                setTimeout(function () {
+                    callback(null, argument + " resolved");
+                }, 15);
+            });
+            async.asyncify(promisified)("argument", function (err, value) {
+                if (err) {
+                    return test.done(new Error(err));
+                }
+                test.ok(value === "argument resolved");
+                test.done();
+            });
+        },
+
+        'reject': function(test) {
+            var promisified = this.Promise.promisify(function(argument, callback) {
+                callback("argument rejected");
+            });
+            async.asyncify(promisified)("argument", function (err) {
+                test.ok(err);
+                test.ok(err.message === "argument rejected");
+                test.done();
+            });
+        }
+    },
+
     'es6-promise': {
         'setUp': function (callback) {
             this.Promise = require('es6-promise').Promise;

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -4275,6 +4275,10 @@ exports['asyncify'] = {
         'es6-promise',
         'rsvp'
     ].reduce(function(promises, name) {
+        if (isBrowser()) {
+            // node only test
+            return;
+        }
         var Promise = require(name);
         if (typeof Promise.Promise === 'function') {
             Promise = Promise.Promise;

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -4269,7 +4269,7 @@ exports['asyncify'] = {
         }
     },
 
-    'bluebird': {
+    'promisified by bluebird': {
         'setUp': function (callback) {
             this.Promise = require('bluebird');
             callback();
@@ -4302,7 +4302,7 @@ exports['asyncify'] = {
         }
     },
 
-    'es6-promise': {
+    'promisified by es6-promise': {
         'setUp': function (callback) {
             this.Promise = require('es6-promise').Promise;
             callback();
@@ -4339,7 +4339,7 @@ exports['asyncify'] = {
         }
     },
     
-    'rsvp': {
+    'promisified by rsvp': {
         'setUp': function (callback) {
             this.Promise = require('rsvp').Promise;
             callback();

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -4274,7 +4274,7 @@ exports['asyncify'] = {
         promises[name] = {
             'resolve': function(test) {
                 var promisified = function(argument) {
-                    return new this.Promise(function (resolve) {
+                    return new Promise(function (resolve) {
                         setTimeout(function () {
                             resolve(argument + " resolved");
                         }, 15);
@@ -4291,7 +4291,7 @@ exports['asyncify'] = {
 
             'reject': function(test) {
                 var promisified = function(argument) {
-                    return new this.Promise(function (resolve, reject) {
+                    return new Promise(function (resolve, reject) {
                         reject(argument + " rejected");
                     });
                 };

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -4269,8 +4269,16 @@ exports['asyncify'] = {
         }
     },
 
-    'promisified': ['bluebird', 'es6-promise', 'rsvp'].reduce(function(promises, name) {
-        var Promise = require(name).Promise;
+    'promisified': [
+        'native-promise-only',
+        'bluebird',
+        'es6-promise',
+        'rsvp'
+    ].reduce(function(promises, name) {
+        var Promise = require(name);
+        if (typeof Promise.Promise === 'function') {
+            Promise = Promise.Promise;
+        }
         promises[name] = {
             'resolve': function(test) {
                 var promisified = function(argument) {

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -4283,7 +4283,7 @@ exports['asyncify'] = {
             });
             async.asyncify(promisified)("argument", function (err, value) {
                 if (err) {
-                    return test.done(new Error(err));
+                    return test.done(new Error("should not get an error here"));
                 }
                 test.ok(value === "argument resolved");
                 test.done();
@@ -4318,7 +4318,7 @@ exports['asyncify'] = {
             };
             async.asyncify(promisified)("argument", function (err, value) {
                 if (err) {
-                    return test.done(new Error(err));
+                    return test.done(new Error("should not get an error here"));
                 }
                 test.ok(value === "argument resolved");
                 test.done();
@@ -4355,7 +4355,7 @@ exports['asyncify'] = {
             };
             async.asyncify(promisified)("argument", function (err, value) {
                 if (err) {
-                    return test.done(new Error(err));
+                    return test.done(new Error("should not get an error here"));
                 }
                 test.ok(value === "argument resolved");
                 test.done();

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -4267,5 +4267,81 @@ exports['asyncify'] = {
           test.ok(e.message === "callback error");
           test.done();
         }
+    },
+
+    'es6-promise': {
+        'setUp': function (callback) {
+            this.Promise = require('es6-promise').Promise;
+            callback();
+        },
+
+        'resolve': function(test) {
+            var promisified = function(argument) {
+                return new this.Promise(function (resolve) {
+                    setTimeout(function () {
+                        resolve(argument + " resolved");
+                    }, 15);
+                });
+            };
+            async.asyncify(promisified)("argument", function (err, value) {
+                if (err) {
+                    return test.done(new Error(err));
+                }
+                test.ok(value === "argument resolved");
+                test.done();
+            });
+        },
+
+        'reject': function(test) {
+            var promisified = function(argument) {
+                return new this.Promise(function (resolve, reject) {
+                    reject(argument + " rejected");
+                });
+            };
+            async.asyncify(promisified)("argument", function (err) {
+                console.log(err.message);
+                test.ok(err);
+                test.ok(err.message === "argument rejected");
+                test.done();
+            });
+        }
+    },
+    
+    'rsvp': {
+        'setUp': function (callback) {
+            this.Promise = require('rsvp').Promise;
+            callback();
+        },
+
+        'resolve': function(test) {
+            var promisified = function(argument) {
+                return new this.Promise(function (resolve) {
+                    setTimeout(function () {
+                        resolve(argument + " resolved");
+                    }, 15);
+                });
+            };
+            async.asyncify(promisified)("argument", function (err, value) {
+                if (err) {
+                    return test.done(new Error(err));
+                }
+                test.ok(value === "argument resolved");
+                test.done();
+            });
+        },
+
+        'reject': function(test) {
+            var promisified = function(argument) {
+                return new this.Promise(function (resolve, reject) {
+                    reject(argument + " rejected");
+                });
+            };
+            async.asyncify(promisified)("argument", function (err) {
+                console.log(err.message);
+                test.ok(err);
+                test.ok(err.message === "argument rejected");
+                test.done();
+            });
+        }
     }
 };

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -4299,7 +4299,6 @@ exports['asyncify'] = {
                 });
             };
             async.asyncify(promisified)("argument", function (err) {
-                console.log(err.message);
                 test.ok(err);
                 test.ok(err.message === "argument rejected");
                 test.done();
@@ -4337,7 +4336,6 @@ exports['asyncify'] = {
                 });
             };
             async.asyncify(promisified)("argument", function (err) {
-                console.log(err.message);
                 test.ok(err);
                 test.ok(err.message === "argument rejected");
                 test.done();

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -4269,110 +4269,39 @@ exports['asyncify'] = {
         }
     },
 
-    'promisified by bluebird': {
-        'setUp': function (callback) {
-            this.Promise = require('bluebird');
-            callback();
-        },
-
-        'resolve': function(test) {
-            var promisified = this.Promise.promisify(function(argument, callback) {
-                setTimeout(function () {
-                    callback(null, argument + " resolved");
-                }, 15);
-            });
-            async.asyncify(promisified)("argument", function (err, value) {
-                if (err) {
-                    return test.done(new Error("should not get an error here"));
-                }
-                test.ok(value === "argument resolved");
-                test.done();
-            });
-        },
-
-        'reject': function(test) {
-            var promisified = this.Promise.promisify(function(argument, callback) {
-                callback("argument rejected");
-            });
-            async.asyncify(promisified)("argument", function (err) {
-                test.ok(err);
-                test.ok(err.message === "argument rejected");
-                test.done();
-            });
-        }
-    },
-
-    'promisified by es6-promise': {
-        'setUp': function (callback) {
-            this.Promise = require('es6-promise').Promise;
-            callback();
-        },
-
-        'resolve': function(test) {
-            var promisified = function(argument) {
-                return new this.Promise(function (resolve) {
-                    setTimeout(function () {
-                        resolve(argument + " resolved");
-                    }, 15);
+    'promisified': ['bluebird', 'es6-promise', 'rsvp'].reduce(function(promises, name) {
+        var Promise = require(name).Promise;
+        promises[name] = {
+            'resolve': function(test) {
+                var promisified = function(argument) {
+                    return new this.Promise(function (resolve) {
+                        setTimeout(function () {
+                            resolve(argument + " resolved");
+                        }, 15);
+                    });
+                };
+                async.asyncify(promisified)("argument", function (err, value) {
+                    if (err) {
+                        return test.done(new Error("should not get an error here"));
+                    }
+                    test.ok(value === "argument resolved");
+                    test.done();
                 });
-            };
-            async.asyncify(promisified)("argument", function (err, value) {
-                if (err) {
-                    return test.done(new Error("should not get an error here"));
-                }
-                test.ok(value === "argument resolved");
-                test.done();
-            });
-        },
+            },
 
-        'reject': function(test) {
-            var promisified = function(argument) {
-                return new this.Promise(function (resolve, reject) {
-                    reject(argument + " rejected");
+            'reject': function(test) {
+                var promisified = function(argument) {
+                    return new this.Promise(function (resolve, reject) {
+                        reject(argument + " rejected");
+                    });
+                };
+                async.asyncify(promisified)("argument", function (err) {
+                    test.ok(err);
+                    test.ok(err.message === "argument rejected");
+                    test.done();
                 });
-            };
-            async.asyncify(promisified)("argument", function (err) {
-                test.ok(err);
-                test.ok(err.message === "argument rejected");
-                test.done();
-            });
-        }
-    },
-    
-    'promisified by rsvp': {
-        'setUp': function (callback) {
-            this.Promise = require('rsvp').Promise;
-            callback();
-        },
-
-        'resolve': function(test) {
-            var promisified = function(argument) {
-                return new this.Promise(function (resolve) {
-                    setTimeout(function () {
-                        resolve(argument + " resolved");
-                    }, 15);
-                });
-            };
-            async.asyncify(promisified)("argument", function (err, value) {
-                if (err) {
-                    return test.done(new Error("should not get an error here"));
-                }
-                test.ok(value === "argument resolved");
-                test.done();
-            });
-        },
-
-        'reject': function(test) {
-            var promisified = function(argument) {
-                return new this.Promise(function (resolve, reject) {
-                    reject(argument + " rejected");
-                });
-            };
-            async.asyncify(promisified)("argument", function (err) {
-                test.ok(err);
-                test.ok(err.message === "argument rejected");
-                test.done();
-            });
-        }
-    }
+            }
+        };
+        return promises;
+    }, {})
 };


### PR DESCRIPTION
Most of Promise realisations doesn't contain `nodeify` method. Here is extention of async wrapper for promisified functions.
For example promise-styled [openpgp](https://github.com/openpgpjs/openpgpjs) library functions looks like
```javascript
openpgp.key.generate(options).then(function(key) {
    // success
}).catch(function(error) {
    // failure
});
```
And can be easily wrapped to use with favourite async:)
```javascript
async.asyncify(openpgp.key.generate);
```
