### PR TITLE
Added detection for using in  Atom/Electron

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -1203,8 +1203,12 @@
         });
     };
 
+    // Electron
+    if (typeof window !== 'undefined' && window.process && window.process.type === "renderer"){
+        root.async = async;
+    }
     // Node.js
-    if (typeof module === 'object' && module.exports) {
+    else if (typeof module === 'object' && module.exports) {
         module.exports = async;
     }
     // AMD / RequireJS


### PR DESCRIPTION
Atom/Electron also exposes module object to the renderer Javascript
context. Currently async.js detects Electron as NodeJs, where as it
should be detected as browser, as suggested by
https://github.com/atom/electron-starter#why-does-my_favorite_library-not-work--do-weird-stuff

The detection snippet is from
https://github.com/atom/electron/issues/2288