### PR TITLE
Allow map to return objects

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -353,7 +353,8 @@
 
     function _asyncMap(eachfn, arr, iterator, callback) {
         callback = _once(callback || noop);
-        var results = [];
+        arr = arr || [];
+        var results = _isArrayLike(arr) ? [] : {};
         eachfn(arr, function (value, index, callback) {
             iterator(value, function (err, v) {
                 results[index] = v;

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -1810,6 +1810,7 @@ exports['map'] = {
         callback(null, val * 2);
     }, function (err, result) {
         if (err) throw err;
+        test.equals(Object.prototype.toString.call(result), '[object Object]');
         test.same(result, {a: 2, b: 4, c: 6});
         test.done();
     });


### PR DESCRIPTION
Map currently will attempt to assign keys to arrays and because of a bug in `nodeunit` this passes unit tests. I think map should either always return an array (ala lodash/underscore) for objects or do as this PR does


/cc @aearly 