### PR TITLE
Adds support for es6 iterators

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -19,6 +19,7 @@
     "sub": true,
     "browser": true,
     "node": true,
+    "esnext": true,
     "globals": {
         "self": true,
         "define": true,

--- a/lib/async.js
+++ b/lib/async.js
@@ -77,12 +77,6 @@
         );
     }
 
-    function _each(coll, iterator) {
-        return _isArrayLike(coll) ?
-            _arrayEach(coll, iterator) :
-            _forEachOf(coll, iterator);
-    }
-
     function _arrayEach(arr, iterator) {
         var index = -1,
             length = arr.length;
@@ -230,23 +224,26 @@
     async.eachOf = function (object, iterator, callback) {
         callback = _once(callback || noop);
         object = object || [];
-        var size = _isArrayLike(object) ? object.length : _keys(object).length;
-        var completed = 0;
-        if (!size) {
-            return callback(null);
-        }
-        _each(object, function (value, key) {
+
+        var iter = _keyIterator(object);
+        var key, completed = 0;
+
+        while ((key = iter()) != null) {
+            completed += 1;
             iterator(object[key], key, only_once(done));
-        });
+        }
+
+        if (completed === 0) callback(null);
+
         function done(err) {
+            completed--;
             if (err) {
                 callback(err);
             }
-            else {
-                completed += 1;
-                if (completed >= size) {
-                    callback(null);
-                }
+            // Check key is null in case iterator isn't exhausted
+            // and done resolved synchronously.
+            else if (key === null && completed <= 0) {
+                callback(null);
             }
         }
     };

--- a/lib/async.js
+++ b/lib/async.js
@@ -19,6 +19,7 @@
         return !v;
     }
 
+
     // global on the server, window in the browser
     var previous_async;
 
@@ -32,6 +33,8 @@
     if (root != null) {
         previous_async = root.async;
     }
+
+    var iteratorSymbol = typeof Symbol == 'function' && Symbol.iterator;
 
     async.noConflict = function () {
         root.async = previous_async;
@@ -131,22 +134,32 @@
         return keys;
     };
 
-    function _keyIterator(coll) {
+    function _iterator(coll) {
         var i = -1;
         var len;
         var keys;
+
         if (_isArrayLike(coll)) {
             len = coll.length;
             return function next() {
                 i++;
-                return i < len ? i : null;
+                return i < len ? [coll[i], i] : null;
             };
-        } else {
+        }
+        else if (iteratorSymbol && coll[iteratorSymbol]) {
+            var iterator = coll[iteratorSymbol]();
+            return function next() {
+                var item = iterator.next();
+                if (item.done) return null;
+                return _isArray(item.value) ? item.value : [item.value];
+            };
+        }
+        else {
             keys = _keys(coll);
             len = keys.length;
             return function next() {
                 i++;
-                return i < len ? keys[i] : null;
+                return i < len ? [coll[keys[i]], keys[i]] : null;
             };
         }
     }
@@ -225,12 +238,12 @@
         callback = _once(callback || noop);
         object = object || [];
 
-        var iter = _keyIterator(object);
-        var key, completed = 0;
+        var iter = _iterator(object);
+        var item, completed = 0;
 
-        while ((key = iter()) != null) {
+        while ((item = iter()) != null) {
             completed += 1;
-            iterator(object[key], key, only_once(done));
+            iterator(item[0], item[1], only_once(done));
         }
 
         if (completed === 0) callback(null);
@@ -242,7 +255,7 @@
             }
             // Check key is null in case iterator isn't exhausted
             // and done resolved synchronously.
-            else if (key === null && completed <= 0) {
+            else if (item === null && completed <= 0) {
                 callback(null);
             }
         }
@@ -252,20 +265,20 @@
     async.eachOfSeries = function (obj, iterator, callback) {
         callback = _once(callback || noop);
         obj = obj || [];
-        var nextKey = _keyIterator(obj);
-        var key = nextKey();
+        var iter = _iterator(obj);
+        var item = iter();
         function iterate() {
             var sync = true;
-            if (key === null) {
+            if (item === null) {
                 return callback(null);
             }
-            iterator(obj[key], key, only_once(function (err) {
+            iterator(item[0], item[1], only_once(function (err) {
                 if (err) {
                     callback(err);
                 }
                 else {
-                    key = nextKey();
-                    if (key === null) {
+                    item = iter();
+                    if (item === null) {
                         return callback(null);
                     } else {
                         if (sync) {
@@ -293,7 +306,7 @@
         return function (obj, iterator, callback) {
             callback = _once(callback || noop);
             obj = obj || [];
-            var nextKey = _keyIterator(obj);
+            var iter = _iterator(obj);
             if (limit <= 0) {
                 return callback(null);
             }
@@ -307,8 +320,8 @@
                 }
 
                 while (running < limit && !errored) {
-                    var key = nextKey();
-                    if (key === null) {
+                    var item = iter();
+                    if (item === null) {
                         done = true;
                         if (running <= 0) {
                             callback(null);
@@ -316,7 +329,7 @@
                         return;
                     }
                     running += 1;
-                    iterator(obj[key], key, only_once(function (err) {
+                    iterator(item[0], item[1], only_once(function (err) {
                         running -= 1;
                         if (err) {
                             callback(err);

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -1347,6 +1347,19 @@ exports['forEachOf'] = function(test){
     });
 };
 
+exports['forEachOf - instant resolver'] = function(test){
+    test.expect(1);
+    var args = [];
+    async.forEachOf({ a: 1, b: 2 }, function(x, k, cb) {
+        args.push(k, x);
+        cb();
+    }, function(){
+        // ensures done callback isn't called before all items iterated
+        test.same(args, ["a", 1, "b", 2]);
+        test.done();
+    });
+};
+
 exports['forEachOf empty object'] = function(test){
     test.expect(1);
     async.forEachOf({}, function(value, key, callback){


### PR DESCRIPTION
Still not sure if this is the right take to address this. The main issues is I expect there will be a perf hit as a result of creating a new array (`[value, key]`) at each step iteration step, instead of  just passing keys directly (benchmarks to follow).

Fixes #839 


**Benchmarks**
```
Comparing v1.3.0 with current on Node v2.3.3
--------------------------------------
each(10) v1.3.0 x 36,160 ops/sec ±3.60% (24 runs sampled), 0.0277ms per run
each(10) current x 35,297 ops/sec ±1.45% (28 runs sampled), 0.0283ms per run
v1.3.0 is faster
--------------------------------------
each(300) v1.3.0 x 6,017 ops/sec ±1.55% (26 runs sampled), 0.166ms per run
each(300) current x 5,883 ops/sec ±1.06% (28 runs sampled), 0.17ms per run
v1.3.0 is faster
--------------------------------------
each(10000) v1.3.0 x 215 ops/sec ±1.33% (28 runs sampled), 4.64ms per run
each(10000) current x 207 ops/sec ±3.90% (28 runs sampled), 4.84ms per run
v1.3.0 is faster
--------------------------------------
eachSeries(10) v1.3.0 x 19,552 ops/sec ±1.27% (27 runs sampled), 0.0511ms per run
eachSeries(10) current x 18,455 ops/sec ±4.19% (26 runs sampled), 0.0542ms per run
v1.3.0 is faster
--------------------------------------
eachSeries(300) v1.3.0 x 1,115 ops/sec ±2.07% (27 runs sampled), 0.897ms per run
eachSeries(300) current x 1,023 ops/sec ±2.77% (25 runs sampled), 0.978ms per run
v1.3.0 is faster
--------------------------------------
eachSeries(10000) v1.3.0 x 35.27 ops/sec ±1.47% (29 runs sampled), 28.4ms per run
eachSeries(10000) current x 31.43 ops/sec ±3.30% (27 runs sampled), 31.8ms per run
v1.3.0 is faster
--------------------------------------
eachLimit(10) v1.3.0 x 25,702 ops/sec ±4.46% (28 runs sampled), 0.0389ms per run
eachLimit(10) current x 25,670 ops/sec ±2.65% (27 runs sampled), 0.039ms per run
Tie
--------------------------------------
eachLimit(300) v1.3.0 x 2,282 ops/sec ±2.68% (28 runs sampled), 0.438ms per run
eachLimit(300) current x 2,321 ops/sec ±3.81% (25 runs sampled), 0.431ms per run
Tie
--------------------------------------
map(10) v1.3.0 x 32,804 ops/sec ±3.23% (25 runs sampled), 0.0305ms per run
map(10) current x 32,166 ops/sec ±1.56% (27 runs sampled), 0.0311ms per run
Tie
--------------------------------------
map(300) v1.3.0 x 5,134 ops/sec ±1.12% (28 runs sampled), 0.195ms per run
map(300) current x 4,830 ops/sec ±2.39% (28 runs sampled), 0.207ms per run
v1.3.0 is faster
--------------------------------------
map(10000) v1.3.0 x 172 ops/sec ±2.41% (28 runs sampled), 5.81ms per run
map(10000) current x 165 ops/sec ±2.19% (28 runs sampled), 6.07ms per run
v1.3.0 is faster
--------------------------------------
mapSeries(10) v1.3.0 x 17,971 ops/sec ±1.44% (27 runs sampled), 0.0556ms per run
mapSeries(10) current x 17,425 ops/sec ±2.19% (27 runs sampled), 0.0574ms per run
v1.3.0 is faster
--------------------------------------
mapSeries(300) v1.3.0 x 969 ops/sec ±3.29% (25 runs sampled), 1.03ms per run
mapSeries(300) current x 962 ops/sec ±2.49% (27 runs sampled), 1.04ms per run
Tie
--------------------------------------
mapSeries(10000) v1.3.0 x 30.75 ops/sec ±4.29% (26 runs sampled), 32.5ms per run
mapSeries(10000) current x 30.44 ops/sec ±5.64% (26 runs sampled), 32.8ms per run
Tie
--------------------------------------
mapLimit(10) v1.3.0 x 24,858 ops/sec ±1.12% (27 runs sampled), 0.0402ms per run
mapLimit(10) current x 25,084 ops/sec ±1.20% (28 runs sampled), 0.0399ms per run
Tie
```