### PR TITLE
Use setImmediate consistently over nextTick

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -272,7 +272,7 @@
                         return callback(null);
                     } else {
                         if (sync) {
-                            async.nextTick(iterate);
+                            async.setImmediate(iterate);
                         } else {
                             iterate();
                         }
@@ -1048,7 +1048,7 @@
             var callback = args.pop();
             var key = hasher.apply(null, args);
             if (key in memo) {
-                async.nextTick(function () {
+                async.setImmediate(function () {
                     callback.apply(null, memo[key]);
                 });
             }


### PR DESCRIPTION
Reminded of this by #903

This probably justifies a patch release... previously on gitter

> **joystick** Now I'm facing some (node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
**megawac** hey @joystick I think you may of found a bug/inconsistency. Want to submit a pull request to the repo changing async.nextTick to async.setImmediate?
**joystick** @megawac I'm not yet ready for PR submission, since I don't know how to fix this. But I will collect info to reproduce the case. This issue is about iterating over array of 1k to 20k elements. Iterator make call to SAP server to find account data information. When I limit array to 200-500 elements no warning issued. if 1k+ I receive warnings about nextTick.
**megawac** @joystick replace nexttick with async.
**joystick**  @megawac I don't call nexttick in my code. please advise where to replace it.
I'm looking for advise if my application has correct logic in general.
**megawac** I'm referring to just replacing all uses of nextTick in async.js (and sending a PR)

/cc @joystick