### PR TITLE
async.queue's task callbacks recursion bug

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -870,7 +870,7 @@
                 if (q.tasks.length + workers === 0) {
                     q.drain();
                 }
-                q.process();
+                async.setImmediate(q.process);
             };
         }
 


### PR DESCRIPTION
async.queue.
once a task finished, the wraped `_next` call `q.process` synchronous, when there has many many tasks, these goes to : **RangeError: Maximum call stack size exceeded**