### PR TITLE
Refactor queue to make it easier to customize behavior

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -852,7 +852,7 @@
         else if(concurrency === 0) {
             throw new Error('Concurrency must not be zero');
         }
-        function _insert(q, data, pos, callback) {
+        function _insert(q, data, pos, processTask, callback) {
             if (callback != null && typeof callback !== "function") {
                 throw new Error("task callback must be a function");
             }
@@ -867,22 +867,14 @@
                 });
             }
             _arrayEach(data, function(task) {
-                var item = {
-                    data: task,
-                    callback: callback || noop
-                };
-
-                if (pos) {
-                    q.tasks.unshift(item);
-                } else {
-                    q.tasks.push(item);
-                }
-
+                q._insertItem(task, pos, callback);
                 if (q.tasks.length === q.concurrency) {
                     q.saturated();
                 }
             });
-            async.setImmediate(q.process);
+            if (processTask) {
+                async.setImmediate(q.process);
+            }
         }
         function _next(q, tasks) {
             return function(){
@@ -918,30 +910,51 @@
             drain: noop,
             started: false,
             paused: false,
+            _insertItem: function (task, pos, callback) {
+                var item = {
+                    data: task,
+                    callback: callback || noop
+                };
+
+                if (pos) {
+                    q.tasks.unshift(item);
+                } else {
+                    q.tasks.push(item);
+                }
+            },
+            _getTasksToProcess: function () {
+                return q.payload ?
+                    q.tasks.splice(0, q.payload) :
+                    q.tasks.splice(0, q.tasks.length);
+            },
+            _push: function (data, pos, processTask, callback) {
+                _insert(q, data, pos, processTask, callback);
+            },
             push: function (data, callback) {
-                _insert(q, data, false, callback);
+                q._push(data, false, true, callback);
             },
             kill: function () {
                 q.drain = noop;
                 q.tasks = [];
             },
             unshift: function (data, callback) {
-                _insert(q, data, true, callback);
+                q._push(data, true, true, callback);
             },
             process: function () {
                 while(!q.paused && workers < q.concurrency && q.tasks.length){
 
-                    var tasks = q.payload ?
-                        q.tasks.splice(0, q.payload) :
-                        q.tasks.splice(0, q.tasks.length);
+                    var tasks = q._getTasksToProcess();
+                    if (q.tasks.length === 0) {
+                        q.empty();
+                    }
+                    if (!tasks || !tasks.length) {
+                        return;
+                    }
 
                     var data = _map(tasks, function (task) {
                         return task.data;
                     });
 
-                    if (q.tasks.length === 0) {
-                        q.empty();
-                    }
                     workers += 1;
                     workersList.push(tasks[0]);
                     var cb = only_once(_next(q, tasks));
@@ -1005,42 +1018,23 @@
             return beg;
         }
 
-        function _insert(q, data, priority, callback) {
-            if (callback != null && typeof callback !== "function") {
-                throw new Error("task callback must be a function");
-            }
-            q.started = true;
-            if (!_isArray(data)) {
-                data = [data];
-            }
-            if(data.length === 0) {
-                // call drain immediately if there are no tasks
-                return async.setImmediate(function() {
-                    q.drain();
-                });
-            }
-            _arrayEach(data, function(task) {
-                var item = {
-                    data: task,
-                    priority: priority,
-                    callback: typeof callback === 'function' ? callback : noop
-                };
-
-                q.tasks.splice(_binarySearch(q.tasks, item, _compareTasks) + 1, 0, item);
-
-                if (q.tasks.length === q.concurrency) {
-                    q.saturated();
-                }
-                async.setImmediate(q.process);
-            });
-        }
-
         // Start with a normal queue
         var q = async.queue(worker, concurrency);
 
+        q._insertItem = function (task, priority, callback) {
+            var item = {
+                data: task,
+                priority: priority,
+                callback: typeof callback === 'function' ? callback : noop
+            };
+
+            q.tasks.splice(_binarySearch(q.tasks, item, _compareTasks) + 1, 0, item);
+            async.setImmediate(q.process);
+        };
+
         // Override push to accept second parameter representing priority
         q.push = function (data, priority, callback) {
-            _insert(q, data, priority, callback);
+            q._push(data, priority, false, callback);
         };
 
         // Remove unshift function


### PR DESCRIPTION
Refer to issue #947.

For an example usage, I have created a 'topical queue', where each queue item is assigned a topic. Each topic can be paused/resumed without impacting other topics. See here: https://github.com/adam-26/async/commit/6ba827d757416ea6dbde21e501511140c400e7fb