### PR TITLE
improve async.series to pass previous results to tasks

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -731,7 +731,20 @@
     };
 
     async.series = function(tasks, callback) {
-        _parallel(async.eachOfSeries, tasks, callback);
+        callback = callback || noop;
+        var results = _isArrayLike(tasks) ? [] : {};
+
+        async.eachOfSeries(tasks, function (task, key, callback) {
+            task(_restParam(function (err, args) {
+                if (args.length <= 1) {
+                    args = args[0];
+                }
+                results[key] = args;
+                callback(err);
+            }), results);
+        }, function (err) {
+            callback(err, results);
+        });
     };
 
     async.iterator = function (tasks) {

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -1112,13 +1112,16 @@ exports['series'] = {
                 callback(null, 1);
             }, 25);
         },
-        function(callback){
+        function(callback, results){
+            test.ok(results[0], 1);
             setTimeout(function(){
                 call_order.push(2);
                 callback(null, 2);
             }, 50);
         },
-        function(callback){
+        function(callback, results){
+            test.ok(results[0], 1);
+            test.ok(results[1], 2); 
             setTimeout(function(){
                 call_order.push(3);
                 callback(null, 3,3);


### PR DESCRIPTION
In issue #957 I've suggested that each async.series task should receive previous tasks results. I've implemented the change. There is a code duplication issue with the _parallel function, I've [tried to refactor](https://github.com/alexpusch/async/commit/bda91c5564f794c2fd8668d8cf286ef451c1ed87) _parallel to accommodate the change but it hearts readability.

As I described in issue #957, I think this change will make async.series much more useful.
