### PR TITLE
Incorrect handling of arguments in "auto" in case of empty callback

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -510,7 +510,7 @@
     };
 
     async.auto = function (tasks, concurrency, callback) {
-        if (!callback) {
+        if (typeof arguments[1] === 'function') {
             // concurrency is optional, shift the args.
             callback = concurrency;
             concurrency = null;

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -426,7 +426,6 @@ exports['auto results'] = function(test){
     });
 };
 
-
 exports['auto empty object'] = function(test){
     async.auto({}, function(err){
         test.ok(err === null, err + " passed instead of 'null'");
@@ -459,6 +458,13 @@ exports['auto no callback'] = function(test){
         task1: function(callback){callback();},
         task2: ['task1', function(callback){callback(); test.done();}]
     });
+};
+
+exports['auto concurrency no callback'] = function(test){
+    async.auto({
+        task1: function(callback){callback();},
+        task2: ['task1', function(callback){callback(); test.done();}]
+    }, 1);
 };
 
 exports['auto error should pass partial results'] = function(test) {


### PR DESCRIPTION
async.auto({....}, 5); -> "fn.apply is not a function"