### PR TITLE
Protect internal "memo" not be changed from outside code

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -1079,6 +1079,7 @@
 
     async.memoize = function (fn, hasher) {
         var memo = {};
+		var publicMemo = {};
         var queues = {};
         hasher = hasher || identity;
         var memoized = _restParam(function memoized(args) {
@@ -1095,7 +1096,7 @@
             else {
                 queues[key] = [callback];
                 fn.apply(null, args.concat([_restParam(function (args) {
-                    memo[key] = args;
+                    publicMemo[key] = memo[key] = args;
                     var q = queues[key];
                     delete queues[key];
                     for (var i = 0, l = q.length; i < l; i++) {
@@ -1104,7 +1105,7 @@
                 })]));
             }
         });
-        memoized.memo = memo;
+        memoized.memo = publicMemo;
         memoized.unmemoized = fn;
         return memoized;
     };

--- a/lib/async.js
+++ b/lib/async.js
@@ -1079,7 +1079,7 @@
 
     async.memoize = function (fn, hasher) {
         var memo = {};
-		var publicMemo = {};
+	    var publicMemo = {};
         var queues = {};
         hasher = hasher || identity;
         var memoized = _restParam(function memoized(args) {

--- a/lib/async.js
+++ b/lib/async.js
@@ -1079,7 +1079,7 @@
 
     async.memoize = function (fn, hasher) {
         var memo = {};
-	    var publicMemo = {};
+        var publicMemo = {};
         var queues = {};
         hasher = hasher || identity;
         var memoized = _restParam(function memoized(args) {


### PR DESCRIPTION
Outside code can change the value in "memo" of the method return by async.memoize. e.g.

var hardAsyncWork = function(name, callback) {
setTimeout(function(){
callback(null, 'get' + name);
}, 5000);
};
var memoizeHardAsyncWork = async.memoize(hardAsyncWork);
memoizeHardAsyncWork('name1', function(error, results){
// step1
console.log(error);
console.log(results);
});
setTimeout(function(){
// if outside code change the memo (be careless) and not in Array format, it may lead to
// exception on callback.apply(null, memo[key]);
memoizeHardAsyncWork.memo['name1'] = ['some other error', 'some other value'];
memoizeHardAsyncWork('name1', function(error, results){
// step2, here the output will different from step1
console.log(error);
console.log(results);
})
}, 9000);