### PR TITLE
prevent return "undefined" immediately when key is "constructor" for memoize method

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -1089,12 +1089,12 @@
         var memoized = _restParam(function memoized(args) {
             var callback = args.pop();
             var key = hasher.apply(null, args);
-            if (key in memo) {
+            if (memo.hasOwnProperty(key)) {
                 async.setImmediate(function () {
                     callback.apply(null, memo[key]);
                 });
             }
-            else if (key in queues) {
+            else if (queues.hasOwnProperty(key)) {
                 queues[key].push(callback);
             }
             else {

--- a/lib/async.js
+++ b/lib/async.js
@@ -1085,16 +1085,17 @@
     async.memoize = function (fn, hasher) {
         var memo = {};
         var queues = {};
+        var has = Object.prototype.hasOwnProperty;
         hasher = hasher || identity;
         var memoized = _restParam(function memoized(args) {
             var callback = args.pop();
             var key = hasher.apply(null, args);
-            if (memo.hasOwnProperty(key)) {
+            if (has.call(memo, key)) {   
                 async.setImmediate(function () {
                     callback.apply(null, memo[key]);
                 });
             }
-            else if (queues.hasOwnProperty(key)) {
+            else if (has.call(queues, key)) {
                 queues[key].push(callback);
             }
             else {

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -4314,9 +4314,9 @@ exports['memoize'] = {
     'avoid constructor key return undefined': function (test) {
     test.expect(1);
     var fn = async.memoize(function(name, callback) {
-        async.setImmediate(function(){
+        setTimeout(function(){
             callback(null, name);
-        });
+        }, 100);
     });
     fn('constructor', function(error, results) {
         test.equal(results, 'constructor');
@@ -4327,12 +4327,25 @@ exports['memoize'] = {
     'avoid __proto__ key return undefined': function (test) {
     test.expect(1);
     var fn = async.memoize(function(name, callback) {
-        async.setImmediate(function(){
+        setTimeout(function(){
             callback(null, name);
-        });
+        }, 100);
     });
     fn('__proto__', function(error, results) {
         test.equal(results, '__proto__');
+        test.done();
+    });
+},
+
+    'allow hasOwnProperty as key': function (test) {
+    test.expect(1);
+    var fn = async.memoize(function(name, callback) {
+        setTimeout(function(){
+            callback(null, name);
+        }, 100);
+    });
+    fn('hasOwnProperty', function(error, results) {
+        test.equal(results, 'hasOwnProperty');
         test.done();
     });
 }

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -4309,6 +4309,32 @@ exports['memoize'] = {
         test.equal(val, "bar");
         test.done();
     });
+},
+
+    'avoid constructor key return undefined': function (test) {
+    test.expect(1);
+    var fn = async.memoize(function(name, callback) {
+        async.setImmediate(function(){
+            callback(null, name);
+        });
+    });
+    fn('constructor', function(error, results) {
+        test.equal(results, 'constructor');
+        test.done();
+    });
+},
+
+    'avoid __proto__ key return undefined': function (test) {
+    test.expect(1);
+    var fn = async.memoize(function(name, callback) {
+        async.setImmediate(function(){
+            callback(null, name);
+        });
+    });
+    fn('__proto__', function(error, results) {
+        test.equal(results, '__proto__');
+        test.done();
+    });
 }
 
 };


### PR DESCRIPTION
when key is "constructor", method after memoized will return "undefined" immediately.

```js
var async = require('async');
var hardAsyncMethod = function(name, callback){
	setTimeout(function(){
		callback(null, 'hello, ' + name);
	}, 5000);
};
var memoizedHardAsyncMethod = async.memoize(hardAsyncMethod);
memoizedHardAsyncMethod('normalString', function(error, results){
	// normal process
	console.log(error);
	console.log(results);
});
memoizedHardAsyncMethod('constructor', function(error, results){
	// will return undefine immediately
	console.log(error);
	console.log(results);
});
```