### PR TITLE
Memoize causes queued callbacks to jump across domains

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -181,6 +181,12 @@
             return iterator(value, callback);
         };
     }
+    
+    // binds a callback to a domain, necessary in Node if a callback may be resolved in a different context, such as with memoize()
+    function bindToCurrentDomain(callback) {
+        if (typeof process !== "object" || process.domain == null || callback == null) return callback;
+        return process.domain.bind(callback);
+    }
 
     //// exported async module functions ////
 
@@ -1095,7 +1101,7 @@
                 });
             }
             else if (key in queues) {
-                queues[key].push(callback);
+                queues[key].push(bindToCurrentDomain(callback));
             }
             else {
                 queues[key] = [callback];

--- a/test/test-async.js
+++ b/test/test-async.js
@@ -4364,12 +4364,7 @@ exports['memoize'] = {
     });
     
     var i = setInterval(function() {
-        if (
-            d1Error === false
-            && d2Error === true
-            && d1Done === true
-            && d2Done === false
-        ) {
+        if (d1Error === false && d2Error === true && d1Done === true && d2Done === false) {
             clearInterval(i);
             test.equal(process.domain, null);
             test.done();


### PR DESCRIPTION
Async.memoize queues up callbacks to prevent a cache-stampede. The result of this is that if you call the same function two times before it's completed, then the second callback will actually be executed in the context of the first. This can cause it to jump across domains because the 2nd callback was originally in the context of another domain, but because it was queued, is now put into the context of the 1st domain. This is solved almost identically to the way that the node mongodb driver handles this same problem. I have added a test case for the scenario.