### PR TITLE
Use `nonexistent` instead of `inexistant` in error message.

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -580,7 +580,7 @@
             var dep;
             while (len--) {
                 if (!(dep = tasks[requires[len]])) {
-                    throw new Error('Has inexistant dependency in ' + requires.join(', '));
+                    throw new Error('Has nonexistent dependency in ' + requires.join(', '));
                 }
                 if (_isArray(dep) && _indexOf(dep, k) >= 0) {
                     throw new Error('Has cyclic dependencies');


### PR DESCRIPTION
Inexistant is not a commonly used English word.