### PR TITLE
It just feel weird to put q.push here

### DIFF
--- a/README.md
+++ b/README.md
@@ -1159,7 +1159,7 @@ __Arguments__
 
 * `worker(task, callback)` - An asynchronous function for processing a queued
   task, which must call its `callback(err)` argument when finished, with an
-  optional `error` as an argument.  If you want to handle errors from an individual task, pass a callback to `q.push()`.
+  optional `error` as an argument.  If you want to handle errors from an individual task, pass a callback to `queue.push()`.
 * `concurrency` - An `integer` for determining how many `worker` functions should be
   run in parallel.  If omitted, the concurrency defaults to `1`.  If the concurrency is `0`, an error is thrown.
 


### PR DESCRIPTION
It is a method of object `queue` and `q` is just a instance of object `queue` in the example.

I know... It's just a very tiny change but it makes it a tiny little better. XD

Also, `queue.push()` seems not mentioned in method list.