### PR TITLE
Set "browser" to index to allow tree-shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Higher-order functions and common patterns for asynchronous code",
   "version": "2.0.0-alpha",
   "main": "dist/async.js",
+  "browser": "index.js",
   "author": "Caolan McMahon",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Brought this up in the main PR but probably better suited for another issue (here ^^). The way we've restructured the repo its well suited for tree-shaking features in webpack and rollup (and other bundlers in the future). This would ease the bundlers ability to cherry-pick only modules used (for instance `forEachOf` as our `index` is just `import` -> `export`. It would also enable lodash modules to be cherry-picked once.

Thoughts @aearly ?


Also should the `/index.js` file point to `lib/index` rather than `build/index` as `build` may or may not exist