### PR TITLE
Support dynamic arguments in async.constant (ref. #1016)

### DIFF
--- a/lib/constant.js
+++ b/lib/constant.js
@@ -4,7 +4,8 @@ import rest from 'lodash/rest';
 
 export default rest(function(values) {
     var args = [null].concat(values);
-    return function (cb) {
-        return cb.apply(this, args);
+    return function () {
+        var callback = [].slice.call(arguments).pop();
+        return callback.apply(this, args);
     };
 });

--- a/mocha_test/constant.js
+++ b/mocha_test/constant.js
@@ -1,0 +1,28 @@
+var async = require('../lib');
+var expect = require('chai').expect;
+
+describe('constant', function () {
+
+    it('basic usage', function(done){
+        var f = async.constant(42, 1, 2, 3);
+        f(function (err, value, a, b, c) {
+            expect(err).to.equal(null);
+            expect(value).to.equal(42);
+            expect(a).to.equal(1);
+            expect(b).to.equal(2);
+            expect(c).to.equal(3);
+            done();
+        });
+    });
+
+    it('called with multiple arguments', function(done){
+        var f = async.constant(42, 1, 2, 3);
+        f('argument to ignore', 'another argument', function (err, value, a) {
+            expect(err).to.equal(null);
+            expect(value).to.equal(42);
+            expect(a).to.equal(1);
+            done();
+        });
+    });
+
+});


### PR DESCRIPTION
Add support for dynamic arguments in constant(), references issue #1016.