### PR TITLE
Use "initialParams" internally to simplify getting callbacks

### DIFF
--- a/lib/asyncify.js
+++ b/lib/asyncify.js
@@ -1,11 +1,10 @@
 'use strict';
 
 import isObject from 'lodash/isObject';
-import rest from 'lodash/rest';
+import initialParams from './internal/initialParams';
 
 export default function asyncify(func) {
-    return rest(function (args) {
-        var callback = args.pop();
+    return initialParams(function (args, callback) {
         var result;
         try {
             result = func.apply(this, args);

--- a/lib/constant.js
+++ b/lib/constant.js
@@ -1,11 +1,11 @@
 'use strict';
 
 import rest from 'lodash/rest';
+import initialParams from './internal/initialParams';
 
 export default rest(function(values) {
     var args = [null].concat(values);
-    return function () {
-        var callback = [].slice.call(arguments).pop();
+    return initialParams(function (ignoredArgs, callback) {
         return callback.apply(this, args);
-    };
+    });
 });

--- a/lib/ensureAsync.js
+++ b/lib/ensureAsync.js
@@ -1,12 +1,10 @@
 'use strict';
 
-import rest from 'lodash/rest';
-
 import setImmediate from './internal/setImmediate';
+import initialParams from './internal/initialParams';
 
 export default function ensureAsync(fn) {
-    return rest(function (args) {
-        var callback = args.pop();
+    return initialParams(function (args, callback) {
         var sync = true;
         args.push(function () {
             var innerArgs = arguments;

--- a/lib/internal/applyEach.js
+++ b/lib/internal/applyEach.js
@@ -1,12 +1,12 @@
 'use strict';
 
 import rest from 'lodash/rest';
+import initialParams from './initialParams';
 
 export default function applyEach(eachfn) {
     return rest(function(fns, args) {
-        var go = rest(function(args) {
+        var go = initialParams(function(args, callback) {
             var that = this;
-            var callback = args.pop();
             return eachfn(fns, function (fn, _, cb) {
                 fn.apply(that, args.concat([cb]));
             },

--- a/lib/internal/initialParams.js
+++ b/lib/internal/initialParams.js
@@ -1,0 +1,9 @@
+import toArray from 'lodash/toArray';
+
+export default function (fn) {
+    return function (/*args..., callback*/) {
+        var args = toArray(arguments);
+        var callback = args.pop();
+        fn(args, callback);
+    };
+}

--- a/lib/internal/initialParams.js
+++ b/lib/internal/initialParams.js
@@ -1,9 +1,8 @@
-import copyArray from 'lodash/_copyArray';
+import rest from 'lodash/rest';
 
 export default function (fn) {
-    return function (/*args..., callback*/) {
-        var args = copyArray(arguments);
+    return rest(function (args/*..., callback*/) {
         var callback = args.pop();
         fn(args, callback);
-    };
+    });
 }

--- a/lib/internal/initialParams.js
+++ b/lib/internal/initialParams.js
@@ -1,8 +1,8 @@
-import toArray from 'lodash/toArray';
+import copyArray from 'lodash/_copyArray';
 
 export default function (fn) {
     return function (/*args..., callback*/) {
-        var args = toArray(arguments);
+        var args = copyArray(arguments);
         var callback = args.pop();
         fn(args, callback);
     };

--- a/lib/memoize.js
+++ b/lib/memoize.js
@@ -5,13 +5,13 @@ import rest from 'lodash/rest';
 import has from 'lodash/has';
 
 import setImmediate from './internal/setImmediate';
+import initialParams from './internal/initialParams';
 
 export default function memoize(fn, hasher) {
     var memo = Object.create(null);
     var queues = Object.create(null);
     hasher = hasher || identity;
-    var memoized = rest(function memoized(args) {
-        var callback = args.pop();
+    var memoized = initialParams(function memoized(args, callback) {
         var key = hasher.apply(null, args);
         if (has(memo, key)) {
             setImmediate(function() {

--- a/lib/retryable.js
+++ b/lib/retryable.js
@@ -1,14 +1,12 @@
 import retry from './retry';
-import rest from 'lodash/rest';
+import initialParams from './internal/initialParams';
 
 export default function (opts, task) {
     if (!task) {
         task = opts;
         opts = null;
     }
-    return rest(function (args) {
-        var callback = args.pop();
-
+    return initialParams(function (args, callback) {
         function taskFn(cb) {
             task.apply(null, args.concat([cb]));
         }

--- a/lib/timeout.js
+++ b/lib/timeout.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import initialParams from './internal/initialParams';
+
 export default function timeout(asyncFn, miliseconds) {
     var originalCallback, timer;
     var timedOut = false;
@@ -18,19 +20,10 @@ export default function timeout(asyncFn, miliseconds) {
         originalCallback(error);
     }
 
-    function injectCallback(asyncFnArgs) {
-        // replace callback in asyncFn args
-        var args = Array.prototype.slice.call(asyncFnArgs, 0);
-        originalCallback = args[args.length - 1];
-        args[args.length - 1] = injectedCallback;
-        return args;
-    }
-
-    function wrappedFn() {
+    return initialParams(function (args, origCallback) {
+        originalCallback = origCallback;
         // setup timer and call original function
         timer = setTimeout(timeoutCallback, miliseconds);
-        asyncFn.apply(null, injectCallback(arguments));
-    }
-
-    return wrappedFn;
+        asyncFn.apply(null, args.concat(injectedCallback));
+    });
 }


### PR DESCRIPTION
A minor internal tweak.  It introduces a new internal function -- `initialParams` -- analagous to `rest`, except it always passes 2 args to the wrapped function -- the intial args and the last arg (usually the callback).  It saves a few lines of code.