### PR TITLE
 Bounded Context on Waterfall via Parameter

### DIFF
--- a/lib/waterfall.js
+++ b/lib/waterfall.js
@@ -62,7 +62,7 @@ import onlyOnce from './internal/onlyOnce';
  *     callback(null, 'done');
  * }
  */
-export default  function(tasks, cb) {
+export default  function(tasks, cb, context) {
     cb = once(cb || noop);
     if (!isArray(tasks)) return cb(new Error('First argument to waterfall must be an array of functions'));
     if (!tasks.length) return cb();
@@ -83,7 +83,7 @@ export default  function(tasks, cb) {
         args.push(taskCallback);
 
         var task = tasks[taskIndex++];
-        task.apply(null, args);
+        task.apply(context || null, args);
     }
 
     nextTask([]);

--- a/mocha_test/waterfall.js
+++ b/mocha_test/waterfall.js
@@ -145,4 +145,40 @@ describe("waterfall", function () {
 
         sameStack = false;
     });
+
+
+    it('bound context with an argument', function(done){
+
+        var vm = require('vm');
+        var context = {
+            name: 'Context',
+            getContextName: function() {
+                return this.name;
+            }
+        };
+
+        var sandbox = {
+            async: async,
+            done: done,
+            context: context,
+            expect: expect
+        };
+
+        var fn = "(" + (function () {
+            async.waterfall([
+                function (cb) {
+                    cb(null, this.getContextName());
+                },
+            ], function(err, result) {
+                expect(err === null);
+                expect(result !== null);
+                expect(result.length > 0);
+                expect(result == context.getContextName());
+                done();
+            }, context);
+        }).toString() + "())";
+
+        vm.runInNewContext(fn, sandbox);
+
+    });
 });


### PR DESCRIPTION
I recently started working with ES6 + Async.Waterfall and I came across the necessity of binding lots of my anonymous functions (arrow functions) to the parent context on my HapiJS API.

Since it depends a lot on some sort of muscle memory to wrap the function in parenthesis and then, binding to "this", I changed this part of the code and added another parameter, named Context that is  applied to the functions.



I came from a .Net background, with DI, IoC and SOLID and I'm trying to apply what I learned the node ecosystem, atleast where I work.

Here is an example of how I've been using


```javascript
'use strict';

const Waterfall = require('async/waterfall');

module.exports = class UserService {

    constructor(userRepository) {
        this.UserRepository = userRepository;
    }
    createUser(payload, reply) {

        Waterfall([
            (callback) => {
                this.UserRepository.createUser(payload).then((createdUser) => {

                    if (!createdUser) {
                        callback({
                            fail: true,
                            message: "Unable to Create the User"
                        }, null);
                    }
                    else {
                        callback(null, createdUser);
                    }
                });
            },
            (createdUser, callback) => {

                const token = this.UserRepository.signIn({
                    id: createdUser._id,
                    username: createdUser.username
                });
                callback(null, {
                    user: createdUser, token: token, auth: true
                });
            }
        ], (err, result) => {

            if (err) {
                reply(err);
            }
            reply(result);
        }, this);
    }
};

```

Otherwise we would have to do it like this
```javascript
((callback) => {
      this.UserRepository.createUser(payload).then((createdUser) => {

              if (!createdUser) {
                  callback({
                  fail: true,
                 message: "Unable to Create the User"
              }, null);
          }
         else {
              callback(null, createdUser);
         }
    });
}).bind(this)

```