### PR TITLE
Fixes #1117

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ $(UMD_BUNDLE_MIN): $(UMD_BUNDLE)
 	mkdir -p "$(@D)"
 	$(UGLIFY) $< --mangle --compress \
 		--source-map $(DIST)/async.min.map \
+		--source-map-url async.min.map \
 		-o $@
 
 $(DIST)/async.js: $(UMD_BUNDLE)


### PR DESCRIPTION
Manually setting the source map URL in the `Makefile`,as when `--source-map` is specified without `--source-map-url`, the source map URL defaults to the values passed to `--source-map`. See
[the uglifyJS options](https://github.com/mishoo/UglifyJS2#user-content-usage). 

I didn't want to commit an entire rebuild of `dist` for a one line fix, but if anything, `dist/async.min.js` can be manually edited to change `//# sourceMappingURL=dist/async.min.map` to `//# sourceMappingURL=async.min.map` before the next rebuild.

Fixes #1117