### PR TITLE
Call out 2.0 breaking changes inline in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,8 +442,7 @@ __Arguments__
 
 * `coll` - A collection to iterate over.
 * `iteratee(item, callback)` - A truth test to apply to each item in `coll`.
-  The `iteratee` is passed a `callback(err, truthValue)`, which must be called with a
-  boolean argument once it has completed.
+  The `iteratee` is passed a `callback(err, truthValue)` , which must be called with a boolean argument once it has completed. **Callback arguments changed in 2.0**
 * `callback(err, results)` - *Optional* A callback which is called after all the `iteratee`
   functions have finished.
 
@@ -548,9 +547,7 @@ If order within the original `coll` is important, then look at `detectSeries`.
 __Arguments__
 
 * `coll` - A collection to iterate over.
-* `iteratee(item, callback)` - A truth test to apply to each item in `coll`.
-  The iteratee is passed a `callback(err, truthValue)` which must be called with a
-  boolean argument once it has completed.
+* `iteratee(item, callback)` - A truth test to apply to each item in `coll`. The iteratee is passed a `callback(err, truthValue)` which must be called with a boolean argument once it has completed. **Callback arguments changed in 2.0**
 * `callback(err, result)` - *Optional* A callback which is called as soon as any iteratee returns
   `true`, or after all the `iteratee` functions have finished. Result will be
   the first item in the array that passes the truth test (iteratee) or the
@@ -640,8 +637,7 @@ __Arguments__
 
 * `coll` - A collection to iterate over.
 * `iteratee(item, callback)` - A truth test to apply to each item in the array
-  in parallel. The iteratee is passed a `callback(err, truthValue)` which must be
-  called with a boolean argument once it has completed.
+  in parallel. The iteratee is passed a `callback(err, truthValue)` which must be called with a boolean argument once it has completed. **Callback arguments changed in 2.0**
 * `callback(err, result)` - *Optional* A callback which is called as soon as any iteratee returns
   `true`, or after all the iteratee functions have finished. Result will be
   either `true` or `false` depending on the values of the async tests.
@@ -677,9 +673,7 @@ If any iteratee call returns `false`, the main `callback` is immediately called.
 __Arguments__
 
 * `coll` - A collection to iterate over.
-* `iteratee(item, callback)` - A truth test to apply to each item in the collection
-  in parallel. The iteratee is passed a `callback(err, truthValue)` which must be
-  called with a  boolean argument once it has completed.
+* `iteratee(item, callback)` - A truth test to apply to each item in the collection in parallel. The iteratee is passed a `callback(err, truthValue)` which must be called with a  boolean argument once it has completed. **Callback arguments changed in 2.0**
 * `callback(err, result)` - *Optional* A callback which is called after all the `iteratee`
   functions have finished. Result will be either `true` or `false` depending on
   the values of the async tests.
@@ -956,7 +950,7 @@ Like [`doWhilst`](#doWhilst), except the `test` is inverted. Note the argument o
 
 Like [`whilst`](#whilst), except the `test` is an asynchronous function that is passed a callback in the form of `function (err, truth)`. If error is passed to `test` or `fn`, the main callback is immediately called with the value of the error.
 
-Additionaly `during` passes any arguments passed by the iteratee function (2nd function) to the test function (1st function). The test callback will allways be the last parameter. 
+Additionaly `during` passes any arguments passed by the iteratee function (2nd function) to the test function (1st function). The test callback will allways be the last parameter.
 
 __Example__
 
@@ -1416,8 +1410,8 @@ async.auto({
 __Arguments__
 
 * `tasks` - An object. Each of its properties is either a function or an array of requirements, with the function itself the last item in the array. The object's key of a property serves as the name of the task defined by that property, i.e. can be used when specifying requirements for other tasks. The function receives one or two arguments:
-  * a `results` object, containing the results of the previously executed functions, only passed if the task has any dependencies,
-  * a `callback(err, result)` function, which must be called when finished, passing an `error` (which can be `null`) and the result of the function's execution.
+  * a `results` object, containing the results of the previously executed functions, only passed if the task has any dependencies, **Argument order changed in 2.0**
+  * a `callback(err, result)` function, which must be called when finished, passing an `error` (which can be `null`) and the result of the function's execution. **Argument order changed in 2.0**
 * `concurrency` - An optional `integer` for determining the maximum number of tasks that can be run in parallel. By default, as many as possible.
 * `callback(err, results)` - An optional callback which is called when all the tasks have been completed. It receives the `err` argument if any `tasks` pass an error to their callback. Results are always returned; however, if an error occurs, no further `tasks` will be performed, and the results object will only contain partial results.
 
@@ -1582,7 +1576,7 @@ __Arguments__
   the function's execution, and (2) a `results` object, containing the results of
   the previously executed functions (if nested inside another control flow).
 * `callback(err, results)` - An optional callback which is called when the
-  task has succeeded, or after the final failed attempt. It receives the `err` and `result` arguments of the last attempt at completing the `task`.
+  task has succeeded, or after the final failed attempt. It receives the `err` and `result` arguments of the last attempt at completing the `task`. **Callback made optional in 2.0, use `retryable` for previous behavior.**
 
 The [`retry`](#retry) function can be used as a stand-alone control flow by passing a callback, as shown below:
 


### PR DESCRIPTION
This might forestall some issues opened while we work on the docs site.  Also might save lots of time for people accidentally reading the new docs and using an old version.