### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Async.js
 
 [![Build Status via Travis CI](https://travis-ci.org/caolan/async.svg?branch=master)](https://travis-ci.org/caolan/async)
-[![NPM version](http://img.shields.io/npm/v/async.svg)](https://www.npmjs.org/package/async)
+[![NPM version](https://img.shields.io/npm/v/async.svg)](https://www.npmjs.com/package/async)
 [![Coverage Status](https://coveralls.io/repos/caolan/async/badge.svg?branch=master)](https://coveralls.io/r/caolan/async?branch=master)
 [![Join the chat at https://gitter.im/caolan/async](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/caolan/async?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
@@ -9,13 +9,13 @@
 
 Async is a utility module which provides straight-forward, powerful functions
 for working with asynchronous JavaScript. Although originally designed for
-use with [Node.js](http://nodejs.org) and installable via `npm install --save async`,
+use with [Node.js](https://nodejs.org/) and installable via `npm install --save async`,
 it can also be used directly in the browser.
 
 Async is also installable via:
 
 - [bower](http://bower.io/): `bower install async`
-- [component](https://github.com/component/component): `component install caolan/async`
+- [component](https://github.com/componentjs/component): `component install caolan/async`
 - [jam](http://jamjs.org/): `jam install async`
 
 Async provides around 70 functions that include the usual 'functional'


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/component/component | https://github.com/componentjs/component 


### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://img.shields.io/npm/v/async.svg | https://img.shields.io/npm/v/async.svg 


### Other Corrected URLs 
Was | Now 
--- | --- 
http://nodejs.org | https://nodejs.org/ 
https://www.npmjs.org/package/async | https://www.npmjs.com/package/async 
