### PR TITLE
Add optional error handler to queues

### DIFF
--- a/lib/internal/queue.js
+++ b/lib/internal/queue.js
@@ -61,6 +61,10 @@ export default function queue(worker, concurrency, payload) {
                 });
 
                 task.callback.apply(task, args);
+
+                if (args[0] != null) {
+                    q.error(args[0], task.data);
+                }
             });
 
             if (workers <= (q.concurrency - q.buffer) ) {
@@ -85,6 +89,7 @@ export default function queue(worker, concurrency, payload) {
         buffer: concurrency / 4,
         empty: noop,
         drain: noop,
+        error: noop,
         started: false,
         paused: false,
         push: function (data, callback) {

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -36,6 +36,8 @@ import queue from './internal/queue';
  * from the `queue` is given to a `worker`.
  * @property {Function} drain - a callback that is called when the last item
  * from the `queue` has returned from the `worker`.
+ * @property {Function} error - a callback that is called when a task errors.
+ * Has the signature `function(error, task)`.
  * @property {boolean} paused - a boolean for determining whether the queue is
  * in a paused state.
  * @property {Function} pause - a function that pauses the processing of tasks


### PR DESCRIPTION
Allowing you to implement things like error logging and task retries more easily, like so:

```javascript
var q = async.queue(function(task, callback) {
	console.log('Oops.');
	callback(new Error('I fail every time'));
});

q.error = function(error, task) {
	if (task.retries == null) task.retries = 0;
	task.retries++;
	if (task.retries < 3) {
		q.push(task);
	} else {
		console.log('This isnt working...');
	}
};

q.push({foo: 'bar'});
```