### PR TITLE
Use nexttick instead of setImmediate

### DIFF
--- a/lib/internal/setImmediate.js
+++ b/lib/internal/setImmediate.js
@@ -4,10 +4,10 @@ import rest from 'lodash/rest';
 var _setImmediate = typeof setImmediate === 'function' && setImmediate;
 
 var _defer;
-if (_setImmediate) {
-    _defer = _setImmediate;
-} else if (typeof process === 'object' && typeof process.nextTick === 'function') {
+if (typeof process === 'object' && typeof process.nextTick === 'function') {
     _defer = process.nextTick;
+} else if (_setImmediate) {
+    _defer = _setImmediate;
 } else {
     _defer = function(fn) {
         setTimeout(fn, 0);


### PR DESCRIPTION
Basically this change is based on @isaacs reflexion on this post:

http://blog.izs.me/post/59142742143/designing-apis-for-asynchrony


> This uses Node’s synthetic deferral function: process.nextTick, which runs the supplied callback at the end of the current run-to-completion. You can also use setImmediate, but that’s slightly slower. (Yes, yes, it’s named badly; setImmediate is slightly less “immediate” and more “next” than nextTick, but this is an accident of history we cannot correct without a time machine.)

Now `internal/setImmediate` implementation is sort based in best optimal solutions first.