### PR TITLE
fix race() anchor in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1814,7 +1814,7 @@ __Related__
 
 ---------------------------------------
 
-<a name="race" />
+<a name="race"></a>
 ### race(tasks, [callback])
 
 Runs the `tasks` array of functions in parallel, without waiting until the


### PR DESCRIPTION
Anchor tags cannot be self-closing. GitHub corrects it, but [npm](https://www.npmjs.com/package/async#race) doesn't:

<img width="781" alt="screen shot 2016-06-13 at 12 01 33 pm" src="https://cloud.githubusercontent.com/assets/114976/16014290/9fc80d68-315e-11e6-9199-c4657d2ea7b8.png">