### PR TITLE
add callbacks to quick examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,15 @@ async.filter(['file1','file2','file3'], function(filePath, callback) {
 });
 
 async.parallel([
-    function(){ ... },
-    function(){ ... }
-], callback);
+    function(callback){ ... },
+    function(callback){ ... }
+], function(err, results) {
+    // optional callback
+};
 
 async.series([
-    function(){ ... },
-    function(){ ... }
+    function(callback){ ... },
+    function(callback){ ... }
 ]);
 ```
 


### PR DESCRIPTION
I got confused for a little bit when I read the quick examples and saw that there was no callback in each of the `.parallel()` and `.series()` functions. So I thought others might also get confused, and added the `callback` parameter to the quick examples.