### PR TITLE
Allow use es6 object method shorthand in autoInject

### DIFF
--- a/lib/autoInject.js
+++ b/lib/autoInject.js
@@ -125,7 +125,6 @@ export default function autoInject(tasks, callback) {
             if (taskFn.length === 0 && params.length === 0) {
                 throw new Error("autoInject task functions require explicit parameters.");
             }
-            console.log(taskFn.length, params)
 
             params.pop();
 

--- a/lib/autoInject.js
+++ b/lib/autoInject.js
@@ -5,10 +5,19 @@ import clone from 'lodash/_copyArray';
 import isArray from 'lodash/isArray';
 import trim from 'lodash/trim';
 
-var argsRegex = /^(function[^\(]*)?\(?\s*([^\)=]*)/m;
+var FN_ARGS = /^(function)?\s*[^\(]*\(\s*([^\)]*)\)/m;
+var FN_ARG_SPLIT = /,/;
+var FN_ARG = /(=.+)?(\s*)$/;
+var STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
 
 function parseParams(func) {
-    return trim(func.toString().match(argsRegex)[2]).split(/\s*\,\s*/);
+    func = func.toString().replace(STRIP_COMMENTS, '');
+    func = func.match(FN_ARGS)[2].replace(' ', '');
+    func = func.split(FN_ARG_SPLIT);
+    func = func.map(function (arg){
+        return trim(arg.replace(FN_ARG, ''));
+    });
+    return func;
 }
 
 /**
@@ -108,8 +117,6 @@ export default function autoInject(tasks, callback) {
             taskFn = params.pop();
 
             newTasks[key] = params.concat(params.length > 0 ? newTask : taskFn);
-        } else if (taskFn.length === 0) {
-            throw new Error("autoInject task functions require explicit parameters.");
         } else if (taskFn.length === 1) {
             // no dependencies, use the function as-is
             newTasks[key] = taskFn;

--- a/lib/autoInject.js
+++ b/lib/autoInject.js
@@ -13,7 +13,7 @@ var STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/mg;
 function parseParams(func) {
     func = func.toString().replace(STRIP_COMMENTS, '');
     func = func.match(FN_ARGS)[2].replace(' ', '');
-    func = func.split(FN_ARG_SPLIT);
+    func = func ? func.split(FN_ARG_SPLIT) : [];
     func = func.map(function (arg){
         return trim(arg.replace(FN_ARG, ''));
     });
@@ -122,6 +122,11 @@ export default function autoInject(tasks, callback) {
             newTasks[key] = taskFn;
         } else {
             params = parseParams(taskFn);
+            if (taskFn.length === 0 && params.length === 0) {
+                throw new Error("autoInject task functions require explicit parameters.");
+            }
+            console.log(taskFn.length, params)
+
             params.pop();
 
             newTasks[key] = params.concat(newTask);

--- a/mocha_test/autoInject.js
+++ b/mocha_test/autoInject.js
@@ -110,5 +110,25 @@ describe('autoInject', function () {
              "    });                                                       " +
              "})                                                            "
         )();
+
+        /* eslint {no-eval: 0}*/
+        eval("(function() {                                                 " +
+             "    it('should work with es6 obj method syntax', function (done) { " +
+             "        async.autoInject({                                    " +
+             "            task1 (cb){             cb(null, 1) },            " +
+             "            task2 ( task3 , cb ) {  cb(null, 2) },            " +
+             "            task3 (cb) {            cb(null, 3) },            " +
+             "            task4 ( task2 , cb ) {  cb(null) },               " +
+             "            task5 ( task4 = 4 , cb ) { cb(null, task4 + 1) }  " +
+             "        }, (err, results) => {                                " +
+             "            expect(results.task1).to.equal(1);                " +
+             "            expect(results.task3).to.equal(3);                " +
+             "            expect(results.task4).to.equal(undefined);        " +
+             "            expect(results.task5).to.equal(5);                " +
+             "            done();                                           " +
+             "        });                                                   " +
+             "    });                                                       " +
+             "})                                                            "
+        )();
     }
 });

--- a/mocha_test/autoInject.js
+++ b/mocha_test/autoInject.js
@@ -110,6 +110,18 @@ describe('autoInject', function () {
              "    });                                                       " +
              "})                                                            "
         )();
+    }
+
+
+    var defaultSupport = true;
+    try {
+        eval('function x(y = 1){ return y }');
+    }catch (e){
+        defaultSupport = false;
+    }
+
+    if(arrowSupport && defaultSupport){
+        // Needs to be run on ES6 only
 
         /* eslint {no-eval: 0}*/
         eval("(function() {                                                 " +

--- a/mocha_test/autoInject.js
+++ b/mocha_test/autoInject.js
@@ -85,6 +85,20 @@ describe('autoInject', function () {
         }, done);
     });
 
+    it('should throw error for function without explicit parameters', function (done) {
+        try {
+            async.autoInject({
+                a: function (){}
+            });
+        } catch (e) {
+            // It's ok. It detected a void function
+            return done();
+        }
+
+        // If didn't catch error, then it's a failed test
+        done(true)
+    });
+
     var arrowSupport = true;
     try {
         new Function('x => x');


### PR DESCRIPTION
This is a patch to fix the current `parseParams` method, in order to work with the new ES6 Method Shorthand type: http://es6-features.org/#MethodProperties, and also the `default` value to work (it's being stripped in parse)

Parser needed to be modified in order to work with:
* defaults. Eg.: `function (dependency = [], cb){ ... }`
* Method shorthand. Eg.: `autoInject({ methodName (someDependency, cb){}, ... }

Also, the validation of `autoInject task functions require explicit parameters` had to be removed, since shorthand methods do not show up with `length > 0`.

This was done because I see a great advantage in using the method shorthand with defaults, to improve readability. Take this example:

```
async.autoInject({
  forgetTo (callback){
     callback(true);
  },
  dont: (forgetTo, callback) => {
     callback();
  },
  so (dont = 'letMe', forgetTo, callback){
     callback(dont);
  },
}, function (err, results){
  // so: 'letMe
  // dont: undefined
  // forgetTo: true
})
```