### PR TITLE
Including a copy of `async` in the docs

### DIFF
--- a/support/esdoc.json
+++ b/support/esdoc.json
@@ -1,5 +1,6 @@
 {
   "source": "./lib",
   "destination": "./docs",
-  "excludes": ["internal"]
+  "excludes": ["internal"],
+  "scripts": ["./dist/async.js"]
 }


### PR DESCRIPTION
This is just a quick update to `support/esdoc.json` to have it include a copy of `async` in the docs generated. This will allow testing it in the console when reading the documentation.