### PR TITLE
Add `files` property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "module",
     "utility"
   ],
+  "files": [
+    "dist/"
+  ],
   "dependencies": {
     "lodash": "^4.8.0",
     "lodash-es": "^4.8.0"


### PR DESCRIPTION
This will allow npm to publish only the `dist/` folder reducing the size of the module.