### PR TITLE
Callback can be called twice in asyncify when using promises.

### DIFF
--- a/lib/asyncify.js
+++ b/lib/asyncify.js
@@ -67,7 +67,7 @@ export default function asyncify(func) {
         if (isObject(result) && typeof result.then === 'function') {
             result.then(function(value) {
                 callback(null, value);
-            })['catch'](function(err) {
+            }, function(err) {
                 callback(err.message ? err : new Error(err));
             });
         } else {


### PR DESCRIPTION
Code to reproduce the bug:
```javascript
const async = require('async');

const i_return_a_promise = () => Promise.resolve("Hello");

const fn = async.asyncify(i_return_a_promise);

var _count = 0;
fn((err) => {
  console.log("CB CALL #%d", ++_count, err);
  throw new Error("D:");
});
```
This code will print out:
```
CB CALL #1 null
CB CALL #2 [Error: D:]
```
This is because `.then` on a promise will catch errors, and return a rejected promise, which would then be caught by the `.catch` code, calling the callback twice. This PR fixes that behavior by handling both the resolve case and the rejection case in the `.then` handler.