### PR TITLE
Remove unhandled rejection listener after asyncify tests are complete

### DIFF
--- a/mocha_test/asyncify.js
+++ b/mocha_test/asyncify.js
@@ -77,8 +77,14 @@ describe('asyncify', function(){
         // Both Bluebird and native promises emit these events. We handle it because Bluebird
         // will report these rejections to stderr if we don't, which is a great feature for
         // normal cases, but not here, since we expect unhandled rejections:
-        process.on('unhandledRejection', function () {
-            // Ignore.
+        function ignoreRejections() {}
+
+        before(function () {
+            process.on('unhandledRejection', ignoreRejections);
+        });
+
+        after(function () {
+            process.removeListener('unhandledRejection', ignoreRejections);
         });
 
         names.forEach(function(name) {


### PR DESCRIPTION
This cleans up the no-op unhandledRejection listener that is attached to the process, so that future tests will correctly report unhandledRejections, should they happen.