### PR TITLE
Optimize queue processing

### DIFF
--- a/lib/internal/queue.js
+++ b/lib/internal/queue.js
@@ -1,5 +1,4 @@
 import arrayEach from 'lodash/_arrayEach';
-import arraySome from 'lodash/_arraySome';
 import isArray from 'lodash/isArray';
 import noop from 'lodash/noop';
 import rest from 'lodash/rest';
@@ -51,10 +50,10 @@ export default function queue(worker, concurrency, payload) {
             workers -= 1;
 
             arrayEach(tasks, function (task) {
-                arraySome(workersList, function (worker, index) {
+                arrayEach(workersList, function (worker, index) {
                     if (worker === task) {
                         workersList.splice(index, 1);
-                        return true;
+                        return false;
                     }
                 });
 

--- a/lib/internal/queue.js
+++ b/lib/internal/queue.js
@@ -1,6 +1,8 @@
 import arrayEach from 'lodash/_arrayEach';
+import arraySome from 'lodash/_arraySome';
 import isArray from 'lodash/isArray';
 import noop from 'lodash/noop';
+import rest from 'lodash/rest';
 
 import onlyOnce from './onlyOnce';
 import setImmediate from './setImmediate';
@@ -45,16 +47,14 @@ export default function queue(worker, concurrency, payload) {
     }
 
     function _next(tasks) {
-        return function(){
+        return rest(function(args){
             workers -= 1;
 
-            var removed = false;
-            var args = arguments;
             arrayEach(tasks, function (task) {
-                arrayEach(workersList, function (worker, index) {
-                    if (worker === task && !removed) {
+                arraySome(workersList, function (worker, index) {
+                    if (worker === task) {
                         workersList.splice(index, 1);
-                        removed = true;
+                        return true;
                     }
                 });
 
@@ -69,11 +69,11 @@ export default function queue(worker, concurrency, payload) {
                 q.unsaturated();
             }
 
-            if (q._tasks.length + workers === 0) {
+            if (q.idle()) {
                 q.drain();
             }
             q.process();
-        };
+        });
     }
 
     var workers = 0;


### PR DESCRIPTION
Applies some JIT  optimizations for arguments and avoids iterating the entire worker set. Then just uses the idle helper because thats what its there for :)