### PR TITLE
Retry should pass all of the resolve arguments to the callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,8 @@ Another big performance win has been re-implementing `queue`, `cargo`, and `prio
 - Added `autoInject`, a relative of `auto` that automatically spreads a task's dependencies as arguments to the task function. (#608, #1055, #1099, #1100)
 - You can now limit the concurrency of `auto` tasks. (#635, #637)
 - Added `retryable`, a relative of `retry` that wraps an async function, making it retry when called. (#1058)
-- `retry` now supports specifying a function that determines the next time interval, useful for exponential backoff and other retry strategies. (#1161)
+- `retry` now supports specifying a function that determines the next time interval, useful for exponential backoff, logging and other retry strategies. (#1161)
+- `retry` will now pass all of the arguments the task function was resolved with to the callback (#1231).
 - Added `q.unsaturated` -- callback called when a `queue`'s number of running workers falls below a threshold. (#868, #1030, #1033, #1034)
 - Added `q.error` -- a callback called whenever a `queue` task calls its callback with an error. (#1170)
 - `applyEach` and `applyEachSeries` now pass results to the final callback. (#1088)

--- a/lib/retry.js
+++ b/lib/retry.js
@@ -109,11 +109,11 @@ export default function retry(opts, task, callback) {
 
     var attempt = 1;
     function retryAttempt() {
-        task(function(err, result) {
+        task(function(err) {
             if (err && attempt++ < options.times) {
                 setTimeout(retryAttempt, options.intervalFunc(attempt));
             } else {
-                callback(err, result);
+                callback.apply(null, arguments);
             }
         });
     }

--- a/mocha_test/retry.js
+++ b/mocha_test/retry.js
@@ -1,6 +1,7 @@
 var async = require('../lib');
 var expect = require('chai').expect;
 var assert = require('assert');
+var _ = require('lodash');
 
 describe("retry", function () {
 
@@ -121,7 +122,7 @@ describe("retry", function () {
         }, 50);
     });
 
-    it('retry does not precompute the intervals (#1226)',function(done) {
+    it('retry does not precompute the intervals (#1226)', function(done) {
         var callTimes = [];
         function intervalFunc() {
             callTimes.push(new Date().getTime());
@@ -135,5 +136,15 @@ describe("retry", function () {
             expect(callTimes[2] - callTimes[1]).to.be.above(99);
             done();
         });
+    });
+
+    it('retry passes all resolve arguments to callback', function(done) {
+        function fn(callback) {
+            callback(null, 1, 2, 3); // respond with indexed values
+        }
+        async.retry(5, fn, _.rest(function(args) {
+            expect(args).to.be.eql([null, 1, 2, 3]);
+            done();
+        }));
     });
 });

--- a/mocha_test/retry.js
+++ b/mocha_test/retry.js
@@ -147,4 +147,14 @@ describe("retry", function () {
             done();
         }));
     });
+
+    // note this is a synchronous test ensuring retry is synchrnous in the fastest (most straightforward) case
+    it('retry calls fn immediately and will call callback if successful', function() {
+        function fn(callback) {
+            callback(null, {a: 1});
+        }
+        async.retry(5, fn, function(err, result) {
+            expect(result).to.be.eql({a: 1});
+        });
+    })
 });


### PR DESCRIPTION
Also adds some coverage for retry simple case where task resolves instantly