### PR TITLE
Fix nyc/code-coverage testing

### DIFF
--- a/mocha_test/parallel.js
+++ b/mocha_test/parallel.js
@@ -192,7 +192,7 @@ describe('parallel', function() {
         });
     });
 
-    it('parallel call in another context', function(done) {
+    it('parallel call in another context @nycinvalid', function(done) {
         if (isBrowser()) {
             // node only test
             done();

--- a/mocha_test/series.js
+++ b/mocha_test/series.js
@@ -137,7 +137,7 @@ describe('series', function() {
         });
     });
 
-    it('call in another context', function(done) {
+    it('call in another context @nycinvalid', function(done) {
         if (isBrowser()) {
             // node only test
             done();

--- a/mocha_test/waterfall.js
+++ b/mocha_test/waterfall.js
@@ -106,7 +106,7 @@ describe("waterfall", function () {
         }).to.throw(/already called/);
     });
 
-    it('call in another context', function(done) {
+    it('call in another context @nycinvalid', function(done) {
         if (process.browser) {
             // node only test
             done();

--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
     "yargs": "~3.9.1"
   },
   "scripts": {
-    "coverage": "nyc npm run mocha-node-test && nyc report",
-    "coveralls": "npm run mocha-node-test && nyc report --reporter=text-lcov | coveralls",
+    "coverage": "nyc npm run mocha-node-test -- --grep @nycinvalid --invert",
+    "coveralls": "npm run mocha-nyc-test && nyc report --reporter=text-lcov | coveralls",
     "jsdoc": "jsdoc -c ./support/jsdoc/jsdoc.json && node support/jsdoc/jsdoc-fix-html.js",
     "lint": "eslint lib/ mocha_test/ perf/memory.js perf/suites.js perf/benchmark.js support/build/ support/*.js karma.conf.js",
     "mocha-browser-test": "karma start",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "scripts": {
     "coverage": "nyc npm run mocha-node-test -- --grep @nycinvalid --invert",
-    "coveralls": "npm run mocha-nyc-test && nyc report --reporter=text-lcov | coveralls",
+    "coveralls": "npm run coverage && nyc report --reporter=text-lcov | coveralls",
     "jsdoc": "jsdoc -c ./support/jsdoc/jsdoc.json && node support/jsdoc/jsdoc-fix-html.js",
     "lint": "eslint lib/ mocha_test/ perf/memory.js perf/suites.js perf/benchmark.js support/build/ support/*.js karma.conf.js",
     "mocha-browser-test": "karma start",


### PR DESCRIPTION
Do not run sub-context tests under nyc.  nyc uses a separate contex to track code, so tests using a separate context fail under nyc with errors like the following:

    1) parallel parallel call in another context:
       ReferenceError: __cov_GLCSDG93mVWqRnbTQi1ISfasEto is not defined
        at evalmachine.<anonymous>:1:16
        at evalmachine.<anonymous>:1:569
        at ContextifyScript.Script.runInNewContext (vm.js:18:15)
        at Object.exports.runInNewContext (vm.js:49:17)
        at Context.<anonymous> (mocha_test/parallel.js:3:954)

This commit also removes the redundant `&& nyc report` from the end of the npm coverage script (nyc outputs the report by default).

fixes #1225