### PR TITLE
Minor cleanups to eachOfLimit

### DIFF
--- a/lib/internal/eachOfLimit.js
+++ b/lib/internal/eachOfLimit.js
@@ -7,21 +7,29 @@ import onlyOnce from './onlyOnce';
 export default function _eachOfLimit(limit) {
     return function (obj, iteratee, callback) {
         callback = once(callback || noop);
-        obj = obj || [];
-        var nextElem = iterator(obj);
-        if (limit <= 0) {
+        if (limit <= 0 || !obj) {
             return callback(null);
         }
+        var nextElem = iterator(obj);
         var done = false;
         var running = 0;
-        var errored = false;
 
-        (function replenish () {
-            if (done && running <= 0) {
+        function iterateeCallback(err) {
+            running -= 1;
+            if (err) {
+                done = true;
+                callback(err);
+            }
+            else if (done && running <= 0) {
                 return callback(null);
             }
+            else {
+                replenish();
+            }
+        }
 
-            while (running < limit && !errored) {
+        function replenish () {
+            while (running < limit && !done) {
                 var elem = nextElem();
                 if (elem === null) {
                     done = true;
@@ -31,18 +39,10 @@ export default function _eachOfLimit(limit) {
                     return;
                 }
                 running += 1;
-                /* eslint {no-loop-func: 0} */
-                iteratee(elem.value, elem.key, onlyOnce(function (err) {
-                    running -= 1;
-                    if (err) {
-                        callback(err);
-                        errored = true;
-                    }
-                    else {
-                        replenish();
-                    }
-                }));
+                iteratee(elem.value, elem.key, onlyOnce(iterateeCallback));
             }
-        })();
+        }
+
+        replenish();
     };
 }


### PR DESCRIPTION
Although I made a couple micro perf optimizations (avoiding a couple extra function calls) there are no real changes to performance.

I did find another minor optimization was to aggressively set the `iterateeCallback` to null when done (in which case we could also kill the done variable)