### PR TITLE
Fast path eachOf array case

### DIFF
--- a/lib/each.js
+++ b/lib/each.js
@@ -1,5 +1,5 @@
-import eachLimit from './eachLimit';
-import doLimit from './internal/doLimit';
+import eachOf from './eachOf';
+import withoutIndex from './internal/withoutIndex';
 
 /**
  * Applies the function `iteratee` to each item in `coll`, in parallel.
@@ -60,4 +60,6 @@ import doLimit from './internal/doLimit';
  *     }
  * });
  */
-export default doLimit(eachLimit, Infinity);
+export default function eachLimit(coll, iteratee, callback) {
+    eachOf(coll, withoutIndex(iteratee), callback);
+}

--- a/lib/eachOf.js
+++ b/lib/eachOf.js
@@ -1,5 +1,36 @@
+import isArrayLike from 'lodash/isArrayLike';
+
 import eachOfLimit from './eachOfLimit';
 import doLimit from './internal/doLimit';
+import noop from 'lodash/noop';
+import once from 'lodash/once';
+import onlyOnce from './internal/onlyOnce';
+
+// eachOf implementation optimized for array-likes
+function eachOfArrayLike(coll, iteratee, callback) {
+    callback = once(callback || noop);
+    var index = 0,
+        completed = 0,
+        length = coll.length;
+    if (length === 0) {
+        callback(null);
+    }
+
+    function iteratorCallback(err) {
+        if (err) {
+            callback(err);
+        } else if (++completed === length) {
+            callback(null);
+        }
+    }
+
+    for (; index < length; index++) {
+        iteratee(coll[index], index, onlyOnce(iteratorCallback));
+    }
+}
+
+// a generic version of eachOf which can handle array, object, and iterator cases.
+var eachOfGeneric = doLimit(eachOfLimit, Infinity);
 
 /**
  * Like [`each`]{@link module:Collections.each}, except that it passes the key (or index) as the second argument
@@ -42,4 +73,7 @@ import doLimit from './internal/doLimit';
  *     doSomethingWith(configs);
  * });
  */
-export default doLimit(eachOfLimit, Infinity);
+export default function(coll, iteratee, callback) {
+    var eachOfImplementation = isArrayLike(coll) ? eachOfArrayLike : eachOfGeneric;
+    eachOfImplementation(coll, iteratee, callback);
+}

--- a/lib/every.js
+++ b/lib/every.js
@@ -1,5 +1,6 @@
-import everyLimit from './everyLimit';
-import doLimit from './internal/doLimit';
+import createTester from './internal/createTester';
+import eachOf from './eachOf';
+import notId from './internal/notId';
 
 /**
  * Returns `true` if every element in `coll` satisfies an async test. If any
@@ -29,4 +30,4 @@ import doLimit from './internal/doLimit';
  *     // if result is true then every file exists
  * });
  */
-export default doLimit(everyLimit, Infinity);
+export default createTester(eachOf, notId, notId);

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -1,5 +1,5 @@
-import filterLimit from './filterLimit';
-import doLimit from './internal/doLimit';
+import filter from './internal/filter';
+import doParallel from './internal/doParallel';
 
 /**
  * Returns a new array of all the values in `coll` which pass an async truth
@@ -28,4 +28,4 @@ import doLimit from './internal/doLimit';
  *     // results now equals an array of the existing files
  * });
  */
-export default doLimit(filterLimit, Infinity);
+export default doParallel(filter);

--- a/lib/map.js
+++ b/lib/map.js
@@ -1,5 +1,5 @@
-import mapLimit from './mapLimit';
-import doLimit from './internal/doLimit';
+import doParallel from './internal/doParallel';
+import map from './internal/map';
 
 /**
  * Produces a new collection of values by mapping each value in `coll` through
@@ -37,4 +37,4 @@ import doLimit from './internal/doLimit';
  *     // results is now an array of stats for each file
  * });
  */
-export default doLimit(mapLimit, Infinity);
+export default doParallel(map);

--- a/lib/parallel.js
+++ b/lib/parallel.js
@@ -1,5 +1,5 @@
-import parallelLimit from './parallelLimit';
-import doLimit from './internal/doLimit';
+import eachOf from './eachOf';
+import parallel from './internal/parallel';
 
 /**
  * Run the `tasks` collection of functions in parallel, without waiting until
@@ -67,4 +67,6 @@ import doLimit from './internal/doLimit';
  *     // results is now equals to: {one: 1, two: 2}
  * });
  */
-export default doLimit(parallelLimit, Infinity);
+export default function parallelLimit(tasks, callback) {
+    parallel(eachOf, tasks, callback);
+}

--- a/lib/reject.js
+++ b/lib/reject.js
@@ -1,5 +1,5 @@
-import rejectLimit from './rejectLimit';
-import doLimit from './internal/doLimit';
+import reject from './internal/reject';
+import doParallel from './internal/doParallel';
 
 /**
  * The opposite of [`filter`]{@link module:Collections.filter}. Removes values that pass an `async` truth test.
@@ -27,4 +27,4 @@ import doLimit from './internal/doLimit';
  *     createFiles(results);
  * });
  */
-export default doLimit(rejectLimit, Infinity);
+export default doParallel(reject);

--- a/lib/some.js
+++ b/lib/some.js
@@ -1,5 +1,6 @@
-import someLimit from './someLimit';
-import doLimit from './internal/doLimit';
+import createTester from './internal/createTester';
+import eachOf from './eachOf';
+import identity from 'lodash/identity';
 
 /**
  * Returns `true` if at least one element in the `coll` satisfies an async test.
@@ -31,4 +32,4 @@ import doLimit from './internal/doLimit';
  *     // if result is true then at least one of the files exists
  * });
  */
-export default doLimit(someLimit, Infinity);
+export default createTester(eachOf, Boolean, identity);

--- a/mocha_test/eachOf.js
+++ b/mocha_test/eachOf.js
@@ -1,6 +1,7 @@
 var async = require('../lib');
 var expect = require('chai').expect;
 var assert = require('assert');
+var _ = require('lodash');
 
 describe("eachOf", function() {
 
@@ -257,6 +258,18 @@ describe("eachOf", function() {
         }, function(err){
             if (err) throw err;
             assert(true, 'should call callback');
+        });
+        setTimeout(done, 25);
+    });
+
+    it('forEachOfLimit no limit', function(done) {
+        var count = 0;
+        async.forEachOfLimit(_.range(100), Infinity, function(x, i, callback){
+            count++;
+            callback();
+        }, function(err){
+            if (err) throw err;
+            expect(count).to.equal(100);
         });
         setTimeout(done, 25);
     });


### PR DESCRIPTION
https://github.com/caolan/async/pull/847 was a valuable change to the code base in which we definetely cleaned things up.

In this PR I want to add a special case, where we consider the array case separate from the generic case. I think this is important as I believe the parallel cases of `each`, `eachOf`, `map`, `filter`, etc when provided arrays are one of the hottest paths in the library. Therefore, I have decided to optimize parallel array processing for all methods which use `eachOf` for the array case and defer to the `eachOfLimit` implementation for objects and iterators.


[On my run of the relevant benchmarks, the suite ran 27.4% faster](https://github.com/caolan/async/files/374892/perf.txt)

/cc @aearly @charlierudolph
