### PR TITLE
Unroll simple loop abstractions

### DIFF
--- a/lib/internal/queue.js
+++ b/lib/internal/queue.js
@@ -1,4 +1,4 @@
-import arrayEach from 'lodash/_arrayEach';
+import indexOf from 'lodash/_baseIndexOf';
 import isArray from 'lodash/isArray';
 import noop from 'lodash/noop';
 import rest from 'lodash/rest';
@@ -23,15 +23,16 @@ export default function queue(worker, concurrency, payload) {
         if (!isArray(data)) {
             data = [data];
         }
-        if(data.length === 0 && q.idle()) {
+        if (data.length === 0 && q.idle()) {
             // call drain immediately if there are no tasks
             return setImmediate(function() {
                 q.drain();
             });
         }
-        arrayEach(data, function(task) {
+
+        for (var i = 0, l = data.length; i < l; i++) {
             var item = {
-                data: task,
+                data: data[i],
                 callback: callback || noop
             };
 
@@ -40,8 +41,7 @@ export default function queue(worker, concurrency, payload) {
             } else {
                 q._tasks.push(item);
             }
-
-        });
+        }
         setImmediate(q.process);
     }
 
@@ -49,20 +49,19 @@ export default function queue(worker, concurrency, payload) {
         return rest(function(args){
             workers -= 1;
 
-            arrayEach(tasks, function (task) {
-                arrayEach(workersList, function (worker, index) {
-                    if (worker === task) {
-                        workersList.splice(index, 1);
-                        return false;
-                    }
-                });
+            for (var i = 0, l = tasks.length; i < l; i++) {
+                var task = tasks[i];
+                var index = indexOf(workersList, task, 0);
+                if (index >= 0) {
+                    workersList.splice(index)
+                }
 
                 task.callback.apply(task, args);
 
                 if (args[0] != null) {
                     q.error(args[0], task.data);
                 }
-            });
+            }
 
             if (workers <= (q.concurrency - q.buffer) ) {
                 q.unsaturated();

--- a/lib/priorityQueue.js
+++ b/lib/priorityQueue.js
@@ -1,4 +1,3 @@
-import arrayEach from 'lodash/_arrayEach';
 import isArray from 'lodash/isArray';
 import noop from 'lodash/noop';
 
@@ -57,9 +56,9 @@ export default function(worker, concurrency) {
             nextNode = nextNode.next;
         }
 
-        arrayEach(data, function(task) {
+        for (var i = 0, l = data.length; i < l; i++) {
             var item = {
-                data: task,
+                data: data[i],
                 priority: priority,
                 callback: callback
             };
@@ -69,7 +68,7 @@ export default function(worker, concurrency) {
             } else {
                 q._tasks.push(item);
             }
-        });
+        }
         setImmediate(q.process);
     };
 

--- a/lib/race.js
+++ b/lib/race.js
@@ -1,5 +1,4 @@
 import isArray from 'lodash/isArray';
-import arrayEach from 'lodash/_arrayEach';
 import noop from 'lodash/noop';
 import once from './internal/once';
 
@@ -44,7 +43,7 @@ export default function race(tasks, callback) {
     callback = once(callback || noop);
     if (!isArray(tasks)) return callback(new TypeError('First argument to race must be an array of functions'));
     if (!tasks.length) return callback();
-    arrayEach(tasks, function (task) {
-        task(callback);
-    });
+    for (var i = 0, l = tasks.length; i < l; i++) {
+        tasks[i](callback);
+    }
 }

--- a/perf/suites.js
+++ b/perf/suites.js
@@ -1,5 +1,6 @@
 var _ = require("lodash");
 var tasks;
+var count;
 
 module.exports = [{
     name: "each",
@@ -91,6 +92,42 @@ module.exports = [{
     fn: function(async, done) {
         async.mapLimit(tasks, 4, function(num, cb) {
             async.setImmediate(cb);
+        }, done);
+    }
+}, {
+    name: "filter",
+    args: [
+        [10],
+        [300],
+        [10000]
+    ],
+    setup: function(c) {
+        count = c;
+        tasks = _.range(count);
+    },
+    fn: function(async, done) {
+        async.filter(tasks, function(num, cb) {
+            async.setImmediate(function() {
+                cb(null, num > (count / 2));
+            });
+        }, done);
+    }
+}, {
+    name: "filterLimit",
+    args: [
+        [10],
+        [300],
+        [10000]
+    ],
+    setup: function(c) {
+        count = c;
+        tasks = _.range(count);
+    },
+    fn: function(async, done) {
+        async.filterLimit(tasks, 10, function(num, cb) {
+            async.setImmediate(function() {
+                cb(null, num > (count / 2));
+            });
         }, done);
     }
 }, {


### PR DESCRIPTION
Figure there is no reason to not write these simple loops our selves.

```
Latest tag is  v2.0.1
Comparing v2.0.1 with current on Node v6.2.2
--------------------------------------
queue(1000) v2.0.1 x 345 ops/sec ±0.80% (30 runs sampled), 2.90ms per run
queue(1000) current x 352 ops/sec ±0.90% (30 runs sampled), 2.84ms per run
current is faster
--------------------------------------
queue(30000) v2.0.1 x 9.39 ops/sec ±3.62% (18 runs sampled), 106ms per run
queue(30000) current x 10.52 ops/sec ±2.89% (20 runs sampled), 95.1ms per run
current is faster
--------------------------------------
queue(100000) v2.0.1 x 2.53 ops/sec ±11.46% (6 runs sampled), 396ms per run
queue(100000) current x 3.05 ops/sec ±8.64% (6 runs sampled), 328ms per run
current is faster
--------------------------------------
queue(200000) v2.0.1 x 1.26 ops/sec ±16.98% (3 runs sampled), 797ms per run
queue(200000) current x 1.43 ops/sec ±11.58% (3 runs sampled), 698ms per run
current is faster
--------------------------------------
current faster overall (1120ms total vs. 1300ms total)
current won more benchmarks (4 vs. 0)
```