### PR TITLE
added alias documentation, fixes #1251

### DIFF
--- a/support/jsdoc/theme/static/styles/jsdoc-default.css
+++ b/support/jsdoc/theme/static/styles/jsdoc-default.css
@@ -403,10 +403,19 @@ code {
   line-height: 30px;
 }
 
+.alias-details {
+    margin-top: -10px;
+    border-left: none;
+}
+
 .details dt {
    width: 120px;
    float: left;
    padding-left: 10px;
+}
+
+.alias-details dt {
+    padding-left: 0px;
 }
 
 .details dd {

--- a/support/jsdoc/theme/tmpl/method.tmpl
+++ b/support/jsdoc/theme/tmpl/method.tmpl
@@ -21,6 +21,13 @@ var self = this;
 </div>
 <?js } ?>
 
+<?js if (data.alias) {?>
+    <dl class="details alias-details">
+        <dt class="tag-alias">Alias:</dt>
+        <dd class="tag-alias"><ul class="dummy"><li><?js= data.alias ?></li></ul></dd>
+    </dl>
+<?js } ?>
+
 <?js if (data.augments && data.alias && data.alias.indexOf('module:') === 0) { ?>
     <h5>Extends:</h5>
     <?js= self.partial('augments.tmpl', data) ?>
@@ -103,5 +110,3 @@ var self = this;
         <?js= self.partial('exceptions.tmpl', r) ?>
     <?js });
 } } ?>
-
-


### PR DESCRIPTION
@megawac this turned out to be a really easy fix, sorry for the delay.

I added the alias right before the parameters:
![image](https://cloud.githubusercontent.com/assets/7647696/17087510/d94e0da8-51d9-11e6-8e65-c3279548c397.png)

Just in case we add multiple alias for a function in the future, I tested it for that too:

```js
 * @alias forEach, anotherAlias
```
![image](https://cloud.githubusercontent.com/assets/7647696/17087521/3f1a0088-51da-11e6-8e7d-f33686fc4f52.png)

Let me know if anything needs to be changed. Thanks.
