### PR TITLE
Adding closing parenthesis to parallel example.

### DIFF
--- a/intro.md
+++ b/intro.md
@@ -45,7 +45,7 @@ async.parallel([
     function(callback){ ... }
 ], function(err, results) {
     // optional callback
-};
+});
 
 async.series([
     function(callback){ ... },


### PR DESCRIPTION
Under Quick Examples the `async.parallel()` example is missing the closing parenthesis. This PR just adds the parenthesis.