### PR TITLE
Fixing inconsistency in whilst jsdoc

### DIFF
--- a/lib/whilst.js
+++ b/lib/whilst.js
@@ -4,7 +4,7 @@ import rest from 'lodash/_baseRest';
 import onlyOnce from './internal/onlyOnce';
 
 /**
- * Repeatedly call `fn`, while `test` returns `true`. Calls `callback` when
+ * Repeatedly call `iteratee`, while `test` returns `true`. Calls `callback` when
  * stopped, or an error occurs.
  *
  * @name whilst
@@ -13,13 +13,13 @@ import onlyOnce from './internal/onlyOnce';
  * @method
  * @category Control Flow
  * @param {Function} test - synchronous truth test to perform before each
- * execution of `fn`. Invoked with ().
+ * execution of `iteratee`. Invoked with ().
  * @param {Function} iteratee - A function which is called each time `test` passes.
  * The function is passed a `callback(err)`, which must be called once it has
  * completed with an optional `err` argument. Invoked with (callback).
  * @param {Function} [callback] - A callback which is called after the test
- * function has failed and repeated execution of `fn` has stopped. `callback`
- * will be passed an error and any arguments passed to the final `fn`'s
+ * function has failed and repeated execution of `iteratee` has stopped. `callback`
+ * will be passed an error and any arguments passed to the final `iteratee`'s
  * callback. Invoked with (err, [results]);
  * @returns undefined
  * @example


### PR DESCRIPTION
The docs are a little confusing here, since they refer to `fn`, but the signature names that argument `iteratee`. I'm just clarifying it here...

Signed-off-by: Dave Henderson <dhenderson@gmail.com>