### PR TITLE
Improve filter by reducing complexity.

### DIFF
--- a/lib/internal/filter.js
+++ b/lib/internal/filter.js
@@ -1,31 +1,19 @@
-import arrayMap from 'lodash/_arrayMap';
-import property from 'lodash/_baseProperty';
+import filter from 'lodash/_arrayFilter';
 import noop from 'lodash/noop';
 import once from './once';
 
 export default function _filter(eachfn, arr, iteratee, callback) {
     callback = once(callback || noop);
-    var results = [];
+    var truthy = [];
     eachfn(arr, function (x, index, callback) {
         iteratee(x, function (err, v) {
-            if (err) {
-                callback(err);
-            }
-            else {
-                if (v) {
-                    results.push({index: index, value: x});
-                }
-                callback();
-            }
+            truthy[index] = !!v;
+            callback(err);
         });
     }, function (err) {
-        if (err) {
-            callback(err);
-        }
-        else {
-            callback(null, arrayMap(results.sort(function (a, b) {
-                return a.index - b.index;
-            }), property('value')));
-        }
+        if (err) return callback(err);
+        callback(null, filter(arr, function (_, index) {
+            return truthy[index];
+        }));
     });
 }

--- a/lib/internal/filter.js
+++ b/lib/internal/filter.js
@@ -1,19 +1,19 @@
-import filter from 'lodash/_arrayFilter';
+import filter from 'lodash/filter';
 import noop from 'lodash/noop';
 import once from './once';
 
 export default function _filter(eachfn, arr, iteratee, callback) {
     callback = once(callback || noop);
-    var truthy = [];
+    var truthValues = new Array(arr.length);
     eachfn(arr, function (x, index, callback) {
         iteratee(x, function (err, v) {
-            truthy[index] = !!v;
+            truthValues[index] = !!v;
             callback(err);
         });
     }, function (err) {
         if (err) return callback(err);
         callback(null, filter(arr, function (_, index) {
-            return truthy[index];
+            return truthValues[index];
         }));
     });
 }

--- a/mocha_test/filter.js
+++ b/mocha_test/filter.js
@@ -41,6 +41,18 @@ describe("filter", function () {
         });
     });
 
+    it('filter collection', function(done){
+        var a = {a: 3, b: 1, c: 2};
+        async.filter(a, function(x, callback){
+            callback(null, x % 2);
+        }, function(err, results){
+            expect(err).to.equal(null);
+            expect(results).to.eql([3,1]);
+            expect(a).to.eql({a: 3, b: 1, c: 2});
+            done();
+        });
+    });
+
     it('filter error', function(done){
         async.filter([3,1,2], function(x, callback){
             callback('error');


### PR DESCRIPTION
This change reduces the complexity of `filter` by removing the need to sort the asynchronous result.

Instead, simply map to a temporary array with the truthy state. In the each function callback filter the original array with the truthy state at the same index.
