### PR TITLE
added scroll-spy behaviour (fixes #1289)

### DIFF
--- a/support/jsdoc/jsdoc-custom.js
+++ b/support/jsdoc/jsdoc-custom.js
@@ -102,4 +102,16 @@ $(function initSearchBar() {
             $('#main').animate({ scrollTop: $el.offsetTop - 60 }, 500);
         }
     });
+
+    function fixOldHash() {
+        var hash = window.location.hash;
+        if (hash) {
+            var hashMatches = hash.match(/^#\.(\w+)$/);
+            if (hashMatches) {
+                window.location.hash = '#'+hashMatches[1];
+            }
+        }
+    }
+
+    fixOldHash();
 });

--- a/support/jsdoc/jsdoc-custom.js
+++ b/support/jsdoc/jsdoc-custom.js
@@ -96,10 +96,10 @@ $(function initSearchBar() {
             location.href = host + suggestion;
         // handle searching from one of the source files or the home page
         } else if (currentPage !== 'docs.html') {
-            location.href = host + 'docs.html#.' + suggestion;
+            location.href = host + 'docs.html#' + suggestion;
         } else {
-            var $el = document.getElementById('.' + suggestion);
-            $('#main').animate({ scrollTop: $el.offsetTop - 60 }, 500);
+            var $el = document.getElementById(suggestion);
+            $('#main-container').animate({ scrollTop: $el.offsetTop - 60 }, 500);
         }
     });
 

--- a/support/jsdoc/jsdoc-fix-html.js
+++ b/support/jsdoc/jsdoc-fix-html.js
@@ -132,9 +132,7 @@ function scrollSpyFix($page, $nav) {
 
     });
 
-    $page.find('[data-type="method"]').each(function() {
-        $(this).addClass("toc-method");
-    });
+    $page.find('[data-type="method"]').addClass("toc-method");
 
     $page.find('[id^="."]').each(function() {
         var $ele = $(this);

--- a/support/jsdoc/jsdoc-fix-html.js
+++ b/support/jsdoc/jsdoc-fix-html.js
@@ -111,11 +111,32 @@ function applyPreCheerioFixes(data) {
 
 function fixToc($page, moduleFiles) {
     // remove `async` listing from toc
-    $page.find('li').find('a[href="'+mainModuleFile+'"]').parent().remove();
+    $page.find('a[href="'+mainModuleFile+'"]').parent().remove();
 
     // change toc title
-    $page.find('nav').children('h3').text(pageTitle);
-    $page.find('nav').children('h2').remove();
+    var $nav = $page.find('nav');
+    $nav.attr('id', 'toc');
+    $nav.children('h3').text(pageTitle);
+    $nav.children('h2').remove();
+
+    // move everything into one big ul (for Bootstrap scroll-spy)
+    var $ul = $nav.children('ul');
+    $ul.addClass('nav').addClass('methods');
+    $ul.find('.methods').each(function() {
+        var $methodsList = $(this);
+        var $methods = $methodsList.find('[data-type="method"]');
+        var $parentLi = $methodsList.parent();
+
+        $methodsList.remove();
+        $methods.remove();
+        $parentLi.after($methods);
+        $parentLi.addClass('toc-header');
+
+    });
+
+    $page.find('[data-type="method"]').each(function() {
+        $(this).addClass("toc-method");
+    });
 
     // make everything point to the same 'docs.html' page
     _.each(moduleFiles, function(filename) {

--- a/support/jsdoc/jsdoc-fix-html.js
+++ b/support/jsdoc/jsdoc-fix-html.js
@@ -22,6 +22,12 @@ var additionalFooterText = ' Documentation has been modified from the original. 
     ' For more information, please see the <a href="https://github.com/caolan/async">async</a> repository.';
 
 function generateHTMLFile(filename, $page, callback) {
+    var methodName = filename.match(/\/(\w+)\.js\.html$/);
+    if (methodName) {
+        var $thisMethodDocLink = $page.find('#toc').find('a[href="'+docFilename+'#'+methodName[1]+'"]');
+        $thisMethodDocLink.parent().addClass('active');
+    }
+
     // generate an HTML file from a cheerio object
     var HTMLdata = HTMLFileBegin + $page.find('head').html()
         + HTMLFileHeadBodyJoin + $page.find('body').html()

--- a/support/jsdoc/theme/static/styles/jsdoc-default.css
+++ b/support/jsdoc/theme/static/styles/jsdoc-default.css
@@ -141,6 +141,30 @@ section, h1 {
   padding: 2em 30px 0;
 }
 
+#toc > h3 {
+    margin-bottom: 0px;
+}
+
+#toc > .methods > li {
+    padding: 0px 10px;
+}
+
+#toc > .methods > li > a {
+    font-size: 12px;
+    padding: 0px;
+}
+
+#toc > .methods > .toc-header {
+    margin-top: 10px;
+}
+
+#toc > .methods > .toc-method > a,
+#toc > .methods > .toc-method > a.active {
+    padding: 0px 0px 0px 20px;
+    border-left: 1px solid #D8DCDF;
+    color: #98999A;
+}
+
 .nav.navbar-right .navbar-form {
     padding: 0;
     margin: 6px 0px;

--- a/support/jsdoc/theme/static/styles/jsdoc-default.css
+++ b/support/jsdoc/theme/static/styles/jsdoc-default.css
@@ -112,18 +112,25 @@ tt, code, kbd, samp {
   bottom: 0;
   float: none;
   min-width: 360px;
-  overflow-y: auto;
-  padding-left: 16px;
-  padding-right: 16px;
+  overflow-y: hidden;
 }
 
-#main h1 {
+#main-container {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    overflow-y: scroll;
+    padding-left: 16px;
+    padding-right: 16px;
+}
+
+#main-container h1 {
     margin-top: 100px !important;
     padding-top: 0px;
     border-left: 2px solid #3391FE;
 }
 
-#main h4 {
+#main-container h4 {
     margin-top: 120px !important;
     padding-top: 0px;
     padding-left: 16px;
@@ -158,11 +165,20 @@ section, h1 {
     margin-top: 10px;
 }
 
+#toc > .methods > .toc-method {
+    padding: 0px;
+    margin: 0px 10px;
+}
+
 #toc > .methods > .toc-method > a,
 #toc > .methods > .toc-method > a.active {
     padding: 0px 0px 0px 20px;
     border-left: 1px solid #D8DCDF;
     color: #98999A;
+}
+
+#toc > .methods > .toc-method.active {
+    background-color: #E8E8E8;
 }
 
 .nav.navbar-right .navbar-form {

--- a/support/jsdoc/theme/tmpl/layout.tmpl
+++ b/support/jsdoc/theme/tmpl/layout.tmpl
@@ -66,11 +66,13 @@
 <label for="nav-trigger" class="overlay"></label>
 
 <div id="main">
-    <?js if (title != 'Home') { ?>
-    <h1 class="page-title"><?js= title ?></h1>
-    <?js } ?>
+    <div id="main-container" data-spy="scroll" data-target="#toc" data-offset="50">
+        <?js if (title != 'Home') { ?>
+        <h1 class="page-title"><?js= title ?></h1>
+        <?js } ?>
 
-    <?js= content ?>
+        <?js= content ?>
+    </div>
 </div>
 
 <nav>


### PR DESCRIPTION
I just wanted a second opinion on this PR because I had to change the ids of the method sections in the body for scroll-spy to work. I just had to remove the `.` in front the ids (`.eachSeries` vs `eachSeries` now). This means that potentially old links to methods in the docs will just point to the top of the old page. I added some js that should minimise this, it replaces the hash in the link with the hash with the `.` removed. It should direct users to the correct method.

I think the ids are a result of the way minami generates them. Its something I should've changed initially when creating the docs. Sorry about that.

Also, to get scroll-spy to work, I had to rearrange some of the HTML/CSS, but from what I can see, everything looks the same as before. I have a live demo on my fork: [http://hargasinski.github.io/async](http://hargasinski.github.io/async).

Thanks in advance for the feedback. 

/cc @megawac @aearly @kalmanh