### PR TITLE
docs: fix typo in expected result for`mapValues()`

### DIFF
--- a/lib/mapValues.js
+++ b/lib/mapValues.js
@@ -27,7 +27,7 @@ import doLimit from './internal/doLimit';
  * transformed value. Invoked with (value, key, callback).
  * @param {Function} [callback] - A callback which is called when all `iteratee`
  * functions have finished, or an error occurs. `result` is a new object consisting
- * of each key from `obj`, with each transformed result on the right-hand side.
+ * of each key from `obj`, with each transformed value on the right-hand side.
  * Invoked with (err, result).
  * @example
  *

--- a/lib/mapValues.js
+++ b/lib/mapValues.js
@@ -26,8 +26,9 @@ import doLimit from './internal/doLimit';
  * called once it has completed with an error (which can be `null`) and a
  * transformed value. Invoked with (value, key, callback).
  * @param {Function} [callback] - A callback which is called when all `iteratee`
- * functions have finished, or an error occurs. Results is an array of the
- * transformed items from the `obj`. Invoked with (err, result).
+ * functions have finished, or an error occurs. `result` is a new object consisting
+ * of each key from `obj`, with each transformed result on the right-hand side.
+ * Invoked with (err, result).
  * @example
  *
  * async.mapValues({
@@ -37,7 +38,7 @@ import doLimit from './internal/doLimit';
  * }, function (file, key, callback) {
  *   fs.stat(file, callback);
  * }, function(err, result) {
- *     // results is now a map of stats for each file, e.g.
+ *     // result is now a map of stats for each file, e.g.
  *     // {
  *     //     f1: [stats for file1],
  *     //     f2: [stats for file2],

--- a/lib/mapValuesLimit.js
+++ b/lib/mapValuesLimit.js
@@ -20,8 +20,9 @@ import once from './internal/once';
  * once it has completed with an error (which can be `null`) and a
  * transformed value. Invoked with (value, key, callback).
  * @param {Function} [callback] - A callback which is called when all `iteratee`
- * functions have finished, or an error occurs. Result is an object of the
- * transformed values from the `obj`. Invoked with (err, result).
+ * functions have finished, or an error occurs. `result` is a new object consisting
+ * of each key from `obj`, with each transformed value on the right-hand side.
+ * Invoked with (err, result).
  */
 export default function mapValuesLimit(obj, limit, iteratee, callback) {
     callback = once(callback || noop);

--- a/lib/mapValuesSeries.js
+++ b/lib/mapValuesSeries.js
@@ -17,7 +17,7 @@ import doLimit from './internal/doLimit';
  * transformed value. Invoked with (value, key, callback).
  * @param {Function} [callback] - A callback which is called when all `iteratee`
  * functions have finished, or an error occurs. `result` is a new object consisting
- * of each key from `obj`, with each transformed result on the right-hand side.
+ * of each key from `obj`, with each transformed value on the right-hand side.
  * Invoked with (err, result).
  */
 export default doLimit(mapValuesLimit, 1);

--- a/lib/mapValuesSeries.js
+++ b/lib/mapValuesSeries.js
@@ -16,7 +16,8 @@ import doLimit from './internal/doLimit';
  * once it has completed with an error (which can be `null`) and a
  * transformed value. Invoked with (value, key, callback).
  * @param {Function} [callback] - A callback which is called when all `iteratee`
- * functions have finished, or an error occurs. Result is an object of the
- * transformed values from the `obj`. Invoked with (err, result).
+ * functions have finished, or an error occurs. `result` is a new object consisting
+ * of each key from `obj`, with each transformed result on the right-hand side.
+ * Invoked with (err, result).
  */
 export default doLimit(mapValuesLimit, 1);


### PR DESCRIPTION
This replaces "array" with "object" (looks like it was likely a copy/paste error from when these docs were originally brought over from `.map()`), and rephrases the sentence accordingly.  I also normalized an occurrence of "result" vs. "results" to match.

> *NOTE:* I did not yet go through and do the same to `.mapValuesLimit()` and `.mapValuesSeries()` in this commit.  I'm happy to take care of that in this PR, but it's purely a matter of copy and pasting the relevant comments.