### PR TITLE
tiny documentation/comment correction

### DIFF
--- a/lib/map.js
+++ b/lib/map.js
@@ -4,7 +4,7 @@ import map from './internal/map';
 /**
  * Produces a new collection of values by mapping each value in `coll` through
  * the `iteratee` function. The `iteratee` is called with an item from `coll`
- * and a callback for when it has finished processing. Each of these callback
+ * and a callback for when it has finished processing. This callback
  * takes 2 arguments: an `error`, and the transformed item from `coll`. If
  * `iteratee` passes an error to its callback, the main `callback` (for the
  * `map` function) is immediately called with the error.


### PR DESCRIPTION
Fixed typo or stale comment. It implied that `map` takes two callbacks, but it really just takes one.

(Sorry to be the guy who files a whole PR for a typo, I'm sort of a compulsive proofreader.)