### PR TITLE
make code examples in docs runnable using RunKit

### DIFF
--- a/lib/reduce.js
+++ b/lib/reduce.js
@@ -40,6 +40,7 @@ import once from './internal/once';
  *     });
  * }, function(err, result) {
  *     // result is now equal to the last value of memo, which is 6
+ *     console.log(result);
  * });
  */
 export default function reduce(coll, memo, iteratee, callback) {

--- a/lib/times.js
+++ b/lib/times.js
@@ -31,6 +31,7 @@ import doLimit from './internal/doLimit';
  *     });
  * }, function(err, users) {
  *     // we should now have 5 users
+ *     console.log(users);
  * });
  */
 export default doLimit(timesLimit, Infinity);

--- a/support/jsdoc/jsdoc-custom.js
+++ b/support/jsdoc/jsdoc-custom.js
@@ -103,6 +103,33 @@ $(function initSearchBar() {
         }
     });
 
+    $('.runkit-run-btn').click(function() {
+        var $btn = $(this);
+        var $container = $btn.closest('.runnable-code');
+        $container.children().hide();
+
+        var source = "var async = require('async');\n";
+        var codeTxt = $container.children('pre').text();
+
+        if (/fs\./.test(codeTxt)) {
+            source += "var fs = require('fs');\n\n" + codeTxt;
+        } else {
+            source += '\n'+codeTxt;
+        }
+
+        var notebook = RunKit.createNotebook({
+            // the parent element for the new notebook
+            element: $container.get(0),
+
+            // specify the source of the notebook
+            source: source,
+
+            onLoad: function(created) {
+                created.evaluate();
+            }
+        });
+    });
+
     function fixOldHash() {
         var hash = window.location.hash;
         if (hash) {

--- a/support/jsdoc/theme/static/styles/jsdoc-default.css
+++ b/support/jsdoc/theme/static/styles/jsdoc-default.css
@@ -138,6 +138,22 @@ tt, code, kbd, samp {
     border-left: 2px solid #3391FE;
 }
 
+.runnable-code {
+    position: relative;
+}
+
+.runkit-run-btn {
+    position: absolute;
+    right: 5px;
+    bottom: 5px;
+    background-color: #3391FE;
+    color: white;
+}
+
+.runkit-run-btn > span {
+    color: white;
+}
+
 header {
   display: block
 }

--- a/support/jsdoc/theme/tmpl/examples.tmpl
+++ b/support/jsdoc/theme/tmpl/examples.tmpl
@@ -7,7 +7,10 @@
     ?>
         <p class="code-caption"><?js= example.caption ?></p>
     <?js } ?>
-    <pre class="prettyprint"><code><?js= self.htmlsafe(example.code) ?></code></pre>
+    <div class="runnable-code">
+        <pre class="prettyprint"><code><?js= self.htmlsafe(example.code) ?></code></pre>
+        <button type="button" class="runkit-run-btn btn btn-primary btn-md">Run</button>
+    </div>
 <?js
     });
 ?>

--- a/support/jsdoc/theme/tmpl/layout.tmpl
+++ b/support/jsdoc/theme/tmpl/layout.tmpl
@@ -23,6 +23,7 @@
     <script src="https://cdn.jsdelivr.net/jquery/2.2.4/jquery.min.js"></script>
     <script src="https://cdn.jsdelivr.net/bootstrap/3.3.6/js/bootstrap.min.js"></script>
     <script src="https://cdn.jsdelivr.net/typeahead.js/0.11.1/typeahead.bundle.min.js"></script>
+    <script src="https://embed.runkit.com"></script>
 </head>
 <body>
 


### PR DESCRIPTION
[RunKit](https://runkit.com/home) essentially creates a sandboxed JS environment to play around with code in the browser. I thought it would be a good way of implementing runnable code examples for the docs. The main advantage is that the environment can be loaded dynamically, so we don't have to slow down the page by loading all 70+ runnable code snippets at once. Lodash already uses it in their [docs](https://lodash.com/docs/4.16.5#chunk).

I have a live demo on my fork: http://hargasinski.github.io/async/docs.html. The [reduce](http://caolan.github.io/async/docs.html#reduce) and [times](http://hargasinski.github.io/async/docs.html#times) docs are probably best for testing it as they don't use `fs`.

The PR isn't ready to be merged yet, as the main issue right now is that a few of our examples use `fs`. I was thinking the best way to handle it would be to change those examples so they don't use `fs`. We could also mock the `fs` functions, similar to how Lodash does it in the [lodash-doc-globals](https://www.npmjs.com/package/lodash-doc-globals) module. I just wanted feedback before moving forward with any of these options. Thanks.

Also, after running a code snippet, there is an `undefined` logged:
![screenshot_20161031_222712](https://cloud.githubusercontent.com/assets/7647696/19877860/3e891be0-9fb9-11e6-8f72-914ecf374da1.png)
That's the `module.exports` value. I don't think there's much I could do about it.
