### PR TITLE
Pr/1297

### DIFF
--- a/lib/internal/filter.js
+++ b/lib/internal/filter.js
@@ -1,27 +1,29 @@
-import isArrayLike from 'lodash/isArrayLike';
+import arrayMap from 'lodash/_arrayMap';
+import property from 'lodash/_baseProperty';
 import noop from 'lodash/noop';
-
 import once from './once';
-import iterator from './iterator';
 
-export default function _filter(eachfn, coll, iteratee, callback) {
+export default function _filter(eachfn, arr, iteratee, callback) {
     callback = once(callback || noop);
-    var truthValues = isArrayLike(coll) ? new Array(coll.length) : {};
-    eachfn(coll, function (x, index, callback) {
+    var results = [];
+    eachfn(arr, function (x, index, callback) {
         iteratee(x, function (err, v) {
-            truthValues[index] = !!v;
-            callback(err);
+            if (err) {
+                callback(err);
+            } else {
+                if (v) {
+                    results.push({index: index, value: x});
+                }
+                callback();
+            }
         });
     }, function (err) {
-        if (err) return callback(err);
-        var result = [];
-        var nextElem = iterator(coll);
-        var elem;
-        while ((elem = nextElem()) !== null) {
-            if (truthValues[elem.key] === true) {
-                result.push(elem.value);
-            }
+        if (err) {
+            callback(err);
+        } else {
+            callback(null, arrayMap(results.sort(function (a, b) {
+                return a.index - b.index;
+            }), property('value')));
         }
-        callback(null, result);
     });
 }

--- a/lib/internal/filter.js
+++ b/lib/internal/filter.js
@@ -1,7 +1,8 @@
-import each from 'lodash/each';
 import isArrayLike from 'lodash/isArrayLike';
 import noop from 'lodash/noop';
+
 import once from './once';
+import iterator from './iterator';
 
 export default function _filter(eachfn, coll, iteratee, callback) {
     callback = once(callback || noop);
@@ -14,11 +15,13 @@ export default function _filter(eachfn, coll, iteratee, callback) {
     }, function (err) {
         if (err) return callback(err);
         var result = [];
-        each(coll, function(_, index) {
-            if (truthValues[index] === true) {
-                result.push(coll[index]);
+        var nextElem = iterator(coll);
+        var elem;
+        while ((elem = nextElem()) !== null) {
+            if (truthValues[elem.key] === true) {
+                result.push(elem.value);
             }
-        });
+        }
         callback(null, result);
     });
 }

--- a/lib/internal/filter.js
+++ b/lib/internal/filter.js
@@ -1,31 +1,19 @@
-import arrayMap from 'lodash/_arrayMap';
-import property from 'lodash/_baseProperty';
+import filter from 'lodash/_arrayFilter';
 import noop from 'lodash/noop';
 import once from './once';
 
 export default function _filter(eachfn, arr, iteratee, callback) {
     callback = once(callback || noop);
-    var results = [];
+    var truthy = [];
     eachfn(arr, function (x, index, callback) {
         iteratee(x, function (err, v) {
-            if (err) {
-                callback(err);
-            }
-            else {
-                if (v) {
-                    results.push({index: index, value: x});
-                }
-                callback();
-            }
+            truthy[index] = !!v;
+            callback(err);
         });
     }, function (err) {
-        if (err) {
-            callback(err);
-        }
-        else {
-            callback(null, arrayMap(results.sort(function (a, b) {
-                return a.index - b.index;
-            }), property('value')));
-        }
+        if (err) return callback(err);
+        callback(null, filter(arr, function (_, index) {
+            return truthy[index];
+        }));
     });
 }

--- a/lib/internal/filter.js
+++ b/lib/internal/filter.js
@@ -1,19 +1,24 @@
-import filter from 'lodash/filter';
+import each from 'lodash/each';
+import isArrayLike from 'lodash/isArrayLike';
 import noop from 'lodash/noop';
 import once from './once';
 
-export default function _filter(eachfn, arr, iteratee, callback) {
+export default function _filter(eachfn, coll, iteratee, callback) {
     callback = once(callback || noop);
-    var truthValues = new Array(arr.length);
-    eachfn(arr, function (x, index, callback) {
+    var truthValues = isArrayLike(coll) ? new Array(coll.length) : {};
+    eachfn(coll, function (x, index, callback) {
         iteratee(x, function (err, v) {
             truthValues[index] = !!v;
             callback(err);
         });
     }, function (err) {
         if (err) return callback(err);
-        callback(null, filter(arr, function (_, index) {
-            return truthValues[index];
-        }));
+        var result = [];
+        each(coll, function(_, index) {
+            if (truthValues[index] === true) {
+                result.push(coll[index]);
+            }
+        });
+        callback(null, result);
     });
 }

--- a/lib/internal/filter.js
+++ b/lib/internal/filter.js
@@ -1,19 +1,19 @@
-import filter from 'lodash/_arrayFilter';
+import filter from 'lodash/filter';
 import noop from 'lodash/noop';
 import once from './once';
 
 export default function _filter(eachfn, arr, iteratee, callback) {
     callback = once(callback || noop);
-    var truthy = [];
+    var truthValues = new Array(arr.length);
     eachfn(arr, function (x, index, callback) {
         iteratee(x, function (err, v) {
-            truthy[index] = !!v;
+            truthValues[index] = !!v;
             callback(err);
         });
     }, function (err) {
         if (err) return callback(err);
         callback(null, filter(arr, function (_, index) {
-            return truthy[index];
+            return truthValues[index];
         }));
     });
 }

--- a/mocha_test/filter.js
+++ b/mocha_test/filter.js
@@ -53,6 +53,37 @@ describe("filter", function () {
         });
     });
 
+    if (typeof Symbol === 'function' && Symbol.iterator) {
+        function makeIterator(array){
+            var nextIndex;
+            let iterator = {
+                next: function(){
+                    return nextIndex < array.length ?
+                       {value: array[nextIndex++], done: false} :
+                       {done: true};
+                }
+            };
+            iterator[Symbol.iterator] = function() {
+                nextIndex = 0; // reset iterator
+                return iterator;
+            };
+            return iterator;
+        }
+
+        it('filter iterator', function(done){
+            var a = makeIterator([500, 20, 100]);
+            async.filter(a, function(x, callback) {
+                setTimeout(function() {
+                    callback(null, x > 20);
+                }, x);
+            }, function(err, results){
+                expect(err).to.equal(null);
+                expect(results).to.eql([500, 100]);
+                done();
+            });
+        });
+    }
+
     it('filter error', function(done){
         async.filter([3,1,2], function(x, callback){
             callback('error');

--- a/mocha_test/filter.js
+++ b/mocha_test/filter.js
@@ -41,6 +41,18 @@ describe("filter", function () {
         });
     });
 
+    it('filter collection', function(done){
+        var a = {a: 3, b: 1, c: 2};
+        async.filter(a, function(x, callback){
+            callback(null, x % 2);
+        }, function(err, results){
+            expect(err).to.equal(null);
+            expect(results).to.eql([3,1]);
+            expect(a).to.eql({a: 3, b: 1, c: 2});
+            done();
+        });
+    });
+
     it('filter error', function(done){
         async.filter([3,1,2], function(x, callback){
             callback('error');


### PR DESCRIPTION
/cc @CodeMan99 we decided to avoid importing lodash/filter in order to avoid including a bunch of unused deep property handling methods (that let lodash support `_.filter(arr, 'a.b.c')`) in our distribution files

Fixes #1297