### PR TITLE
Cleanup some of the dependency imports

### DIFF
--- a/lib/apply.js
+++ b/lib/apply.js
@@ -1,4 +1,4 @@
-import rest from 'lodash/_baseRest';
+import rest from './internal/rest';
 
 /**
  * Creates a continuation function with some arguments already applied.

--- a/lib/auto.js
+++ b/lib/auto.js
@@ -4,7 +4,7 @@ import indexOf from 'lodash/_baseIndexOf';
 import isArray from 'lodash/isArray';
 import okeys from 'lodash/keys';
 import noop from 'lodash/noop';
-import rest from 'lodash/_baseRest';
+import rest from './internal/rest';
 
 import once from './internal/once';
 import onlyOnce from './internal/onlyOnce';

--- a/lib/autoInject.js
+++ b/lib/autoInject.js
@@ -1,7 +1,6 @@
 import auto from './auto';
 import forOwn from 'lodash/_baseForOwn';
 import arrayMap from 'lodash/_arrayMap';
-import clone from 'lodash/_copyArray';
 import isArray from 'lodash/isArray';
 import trim from 'lodash/trim';
 
@@ -109,8 +108,8 @@ export default function autoInject(tasks, callback) {
         var params;
 
         if (isArray(taskFn)) {
-            params = clone(taskFn);
-            taskFn = params.pop();
+            params = taskFn.slice(0, -1);
+            taskFn = taskFn[taskFn.length - 1];
 
             newTasks[key] = params.concat(params.length > 0 ? newTask : taskFn);
         } else if (taskFn.length === 1) {

--- a/lib/compose.js
+++ b/lib/compose.js
@@ -1,5 +1,5 @@
 import seq from './seq';
-import rest from 'lodash/_baseRest';
+import rest from './internal/rest';
 
 /**
  * Creates a function which is a composition of the passed asynchronous

--- a/lib/constant.js
+++ b/lib/constant.js
@@ -1,4 +1,4 @@
-import rest from 'lodash/_baseRest';
+import rest from './internal/rest';
 import initialParams from './internal/initialParams';
 
 /**

--- a/lib/doDuring.js
+++ b/lib/doDuring.js
@@ -1,5 +1,5 @@
 import noop from 'lodash/noop';
-import rest from 'lodash/_baseRest';
+import rest from './internal/rest';
 import onlyOnce from './internal/onlyOnce';
 
 /**

--- a/lib/doWhilst.js
+++ b/lib/doWhilst.js
@@ -1,5 +1,5 @@
 import noop from 'lodash/noop';
-import rest from 'lodash/_baseRest';
+import rest from './internal/rest';
 
 import onlyOnce from './internal/onlyOnce';
 

--- a/lib/internal/applyEach.js
+++ b/lib/internal/applyEach.js
@@ -1,4 +1,4 @@
-import rest from 'lodash/_baseRest';
+import rest from './rest';
 import initialParams from './initialParams';
 
 export default function applyEach(eachfn) {

--- a/lib/internal/consoleFunc.js
+++ b/lib/internal/consoleFunc.js
@@ -1,5 +1,5 @@
 import arrayEach from 'lodash/_arrayEach';
-import rest from 'lodash/_baseRest';
+import rest from './rest';
 
 export default function consoleFunc(name) {
     return rest(function (fn, args) {

--- a/lib/internal/initialParams.js
+++ b/lib/internal/initialParams.js
@@ -1,4 +1,4 @@
-import rest from 'lodash/_baseRest';
+import rest from './rest';
 
 export default function (fn) {
     return rest(function (args/*..., callback*/) {

--- a/lib/internal/map.js
+++ b/lib/internal/map.js
@@ -1,8 +1,7 @@
 import noop from 'lodash/noop';
-import once from './once';
 
 export default function _asyncMap(eachfn, arr, iteratee, callback) {
-    callback = once(callback || noop);
+    callback = callback || noop;
     arr = arr || [];
     var results = [];
     var counter = 0;

--- a/lib/internal/parallel.js
+++ b/lib/internal/parallel.js
@@ -1,6 +1,6 @@
 import noop from 'lodash/noop';
 import isArrayLike from 'lodash/isArrayLike';
-import rest from 'lodash/_baseRest';
+import rest from './rest';
 
 export default function _parallel(eachfn, tasks, callback) {
     callback = callback || noop;

--- a/lib/internal/queue.js
+++ b/lib/internal/queue.js
@@ -1,7 +1,7 @@
 import indexOf from 'lodash/_baseIndexOf';
 import isArray from 'lodash/isArray';
 import noop from 'lodash/noop';
-import rest from 'lodash/_baseRest';
+import rest from './rest';
 
 import onlyOnce from './onlyOnce';
 import setImmediate from './setImmediate';

--- a/lib/internal/reject.js
+++ b/lib/internal/reject.js
@@ -3,11 +3,7 @@ import filter from './filter';
 export default function reject(eachfn, arr, iteratee, callback) {
     filter(eachfn, arr, function(value, cb) {
         iteratee(value, function(err, v) {
-            if (err) {
-                cb(err);
-            } else {
-                cb(null, !v);
-            }
+            cb(err, !v);
         });
     }, callback);
 }

--- a/lib/internal/rest.js
+++ b/lib/internal/rest.js
@@ -1,0 +1,8 @@
+import _overRest from 'lodash/_overRest';
+import identity from 'lodash/identity';
+
+// Lodash rest function without function.toString()
+// remappings
+export default function rest(func, start) {
+    return _overRest(func, start, identity);
+}

--- a/lib/internal/setImmediate.js
+++ b/lib/internal/setImmediate.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import rest from 'lodash/_baseRest';
+import rest from './rest';
 
 export var hasSetImmediate = typeof setImmediate === 'function' && setImmediate;
 export var hasNextTick = typeof process === 'object' && typeof process.nextTick === 'function';

--- a/lib/memoize.js
+++ b/lib/memoize.js
@@ -1,5 +1,5 @@
 import identity from 'lodash/identity';
-import rest from 'lodash/_baseRest';
+import rest from './internal/rest';
 
 import setImmediate from './internal/setImmediate';
 import initialParams from './internal/initialParams';

--- a/lib/reflect.js
+++ b/lib/reflect.js
@@ -1,5 +1,5 @@
 import initialParams from './internal/initialParams';
-import rest from 'lodash/_baseRest';
+import rest from './internal/rest';
 
 /**
  * Wraps the function in another function that always returns data even when it

--- a/lib/seq.js
+++ b/lib/seq.js
@@ -1,5 +1,5 @@
 import noop from 'lodash/noop';
-import rest from 'lodash/_baseRest';
+import rest from './internal/rest';
 import reduce from './reduce';
 
 /**

--- a/lib/waterfall.js
+++ b/lib/waterfall.js
@@ -1,7 +1,7 @@
 import isArray from 'lodash/isArray';
 import noop from 'lodash/noop';
 import once from './internal/once';
-import rest from 'lodash/_baseRest';
+import rest from './internal/rest';
 
 import onlyOnce from './internal/onlyOnce';
 

--- a/lib/whilst.js
+++ b/lib/whilst.js
@@ -1,5 +1,5 @@
 import noop from 'lodash/noop';
-import rest from 'lodash/_baseRest';
+import rest from './internal/rest';
 
 import onlyOnce from './internal/onlyOnce';
 


### PR DESCRIPTION
Saves 800 bytes on min.js

fyi _baseRest imports a bunch of string manipulation code to manage setting `func.toString` on the output function