### PR TITLE
remove unnecessary arrays

### DIFF
--- a/dist/async.js
+++ b/dist/async.js
@@ -95,7 +95,7 @@ function applyEach$1(eachfn) {
         var go = initialParams(function (args, callback) {
             var that = this;
             return eachfn(fns, function (fn, cb) {
-                fn.apply(that, args.concat([cb]));
+                fn.apply(that, args.concat(cb));
             }, callback);
         });
         if (args.length) {
@@ -2535,9 +2535,9 @@ var seq$1 = rest(function seq(functions) {
         }
 
         reduce(functions, args, function (newargs, fn, cb) {
-            fn.apply(that, newargs.concat([rest(function (err, nextargs) {
+            fn.apply(that, newargs.concat(rest(function (err, nextargs) {
                 cb(err, nextargs);
-            })]));
+            })));
         }, function (err, results) {
             cb.apply(that, [err].concat(results));
         });
@@ -2822,7 +2822,7 @@ var detectSeries = _createTester(eachOfSeries, identity, _findGetResult);
 
 function consoleFunc(name) {
     return rest(function (fn, args) {
-        fn.apply(null, args.concat([rest(function (err, args) {
+        fn.apply(null, args.concat(rest(function (err, args) {
             if (typeof console === 'object') {
                 if (err) {
                     if (console.error) {
@@ -2834,7 +2834,7 @@ function consoleFunc(name) {
                     });
                 }
             }
-        })]));
+        })));
     });
 }
 
@@ -2923,7 +2923,7 @@ function doDuring(fn, test, callback) {
  * passes. The function is passed a `callback(err)`, which must be called once
  * it has completed with an optional `err` argument. Invoked with (callback).
  * @param {Function} test - synchronous truth test to perform after each
- * execution of `iteratee`. Invoked with the non-error callback results of 
+ * execution of `iteratee`. Invoked with the non-error callback results of
  * `iteratee`.
  * @param {Function} [callback] - A callback which is called after the test
  * function has failed and repeated execution of `iteratee` has stopped.
@@ -3620,14 +3620,14 @@ function memoize(fn, hasher) {
             queues[key].push(callback);
         } else {
             queues[key] = [callback];
-            fn.apply(null, args.concat([rest(function (args) {
+            fn.apply(null, args.concat(rest(function (args) {
                 memo[key] = args;
                 var q = queues[key];
                 delete queues[key];
                 for (var i = 0, l = q.length; i < l; i++) {
                     q[i].apply(null, args);
                 }
-            })]));
+            })));
         }
     });
     memoized.memo = memo;
@@ -4450,7 +4450,7 @@ var retryable = function (opts, task) {
     }
     return initialParams(function (args, callback) {
         function taskFn(cb) {
-            task.apply(null, args.concat([cb]));
+            task.apply(null, args.concat(cb));
         }
 
         if (opts) retry(opts, taskFn, callback);else retry(taskFn, callback);

--- a/lib/internal/applyEach.js
+++ b/lib/internal/applyEach.js
@@ -6,7 +6,7 @@ export default function applyEach(eachfn) {
         var go = initialParams(function(args, callback) {
             var that = this;
             return eachfn(fns, function (fn, cb) {
-                fn.apply(that, args.concat([cb]));
+                fn.apply(that, args.concat(cb));
             }, callback);
         });
         if (args.length) {

--- a/lib/internal/consoleFunc.js
+++ b/lib/internal/consoleFunc.js
@@ -3,7 +3,7 @@ import rest from './rest';
 
 export default function consoleFunc(name) {
     return rest(function (fn, args) {
-        fn.apply(null, args.concat([rest(function (err, args) {
+        fn.apply(null, args.concat(rest(function (err, args) {
             if (typeof console === 'object') {
                 if (err) {
                     if (console.error) {
@@ -16,6 +16,6 @@ export default function consoleFunc(name) {
                     });
                 }
             }
-        })]));
+        })));
     });
 }

--- a/lib/memoize.js
+++ b/lib/memoize.js
@@ -59,14 +59,14 @@ export default function memoize(fn, hasher) {
             queues[key].push(callback);
         } else {
             queues[key] = [callback];
-            fn.apply(null, args.concat([rest(function(args) {
+            fn.apply(null, args.concat(rest(function(args) {
                 memo[key] = args;
                 var q = queues[key];
                 delete queues[key];
                 for (var i = 0, l = q.length; i < l; i++) {
                     q[i].apply(null, args);
                 }
-            })]));
+            })));
         }
     });
     memoized.memo = memo;

--- a/lib/retryable.js
+++ b/lib/retryable.js
@@ -32,7 +32,7 @@ export default function (opts, task) {
     }
     return initialParams(function (args, callback) {
         function taskFn(cb) {
-            task.apply(null, args.concat([cb]));
+            task.apply(null, args.concat(cb));
         }
 
         if (opts) retry(opts, taskFn, callback);

--- a/lib/seq.js
+++ b/lib/seq.js
@@ -52,9 +52,9 @@ export default rest(function seq(functions) {
         }
 
         reduce(functions, args, function(newargs, fn, cb) {
-            fn.apply(that, newargs.concat([rest(function(err, nextargs) {
+            fn.apply(that, newargs.concat(rest(function(err, nextargs) {
                 cb(err, nextargs);
-            })]));
+            })));
         },
         function(err, results) {
             cb.apply(that, [err].concat(results));


### PR DESCRIPTION
removed unnecessary arrays

Array.prototype.concat can be used like so

`[1,2,3].concat(4)`

you don't need to do

`[1,2,3].concat([4])`