### PR TITLE
Pr/1267

### DIFF
--- a/lib/internal/queue.js
+++ b/lib/internal/queue.js
@@ -149,12 +149,7 @@ export default function queue(worker, concurrency, payload) {
         resume: function () {
             if (q.paused === false) { return; }
             q.paused = false;
-            var resumeCount = Math.min(q.concurrency, q._tasks.length);
-            // Need to call q.process once per concurrent
-            // worker to preserve full concurrency after pause
-            for (var w = 1; w <= resumeCount; w++) {
-                setImmediate(q.process);
-            }
+            setImmediate(q.process);
         }
     };
     return q;

--- a/lib/internal/queue.js
+++ b/lib/internal/queue.js
@@ -70,15 +70,13 @@ export default function queue(worker, concurrency, payload) {
             if (q.idle()) {
                 q.drain();
             }
-            if (!sync) {
-                q.process();
-            }
+            q.process();
         });
     }
 
     var workers = 0;
-    var sync = 0;
     var workersList = [];
+    var isProcessing = false;
     var q = {
         _tasks: new DLL(),
         concurrency: concurrency,
@@ -102,6 +100,12 @@ export default function queue(worker, concurrency, payload) {
             _insert(data, true, callback);
         },
         process: function () {
+            // Avoid trying to start too many processing operations. This can occur
+            // when callbacks resolve synchronously (#1267).
+            if (isProcessing) {
+                return;
+            }
+            isProcessing = true;
             while(!q.paused && workers < q.concurrency && q._tasks.length){
                 var tasks = [], data = [];
                 var l = q._tasks.length;
@@ -123,15 +127,9 @@ export default function queue(worker, concurrency, payload) {
                 }
 
                 var cb = onlyOnce(_next(tasks));
-
-                // prevent stack growth when calling callback synchronously:
-                // unroll the recursion into a loop here. (The callback will
-                // have reduced the workers count synchronously, causing us to
-                // loop again)
-                sync = 1;
                 worker(data, cb);
-                sync = 0;
             }
+            isProcessing = false;
         },
         length: function () {
             return q._tasks.length;

--- a/lib/internal/queue.js
+++ b/lib/internal/queue.js
@@ -70,11 +70,14 @@ export default function queue(worker, concurrency, payload) {
             if (q.idle()) {
                 q.drain();
             }
-            q.process();
+            if (!sync) {
+                q.process();
+            }
         });
     }
 
     var workers = 0;
+    var sync = 0;
     var workersList = [];
     var q = {
         _tasks: new DLL(),
@@ -120,7 +123,14 @@ export default function queue(worker, concurrency, payload) {
                 }
 
                 var cb = onlyOnce(_next(tasks));
+
+                // prevent stack growth when calling callback synchronously:
+                // unroll the recursion into a loop here. (The callback will
+                // have reduced the workers count synchronously, causing us to
+                // loop again)
+                sync = 1;
                 worker(data, cb);
+                sync = 0;
             }
         },
         length: function () {


### PR DESCRIPTION
The reason I prefer this approach is conceptually we're not tracking whether the callback the user provides is synchronous, rather we're just checking if we're already trying to run this function. I'll admit that this ends up doing virtually the same thing as #1267,  to me, it is just easier to reason why its necessary

/cc @autopulated @aearly for thoughts