### PR TITLE
Add aliases to toc (related to #1339)

### DIFF
--- a/lib/nextTick.js
+++ b/lib/nextTick.js
@@ -14,7 +14,6 @@ import { hasNextTick, hasSetImmediate, fallback, wrap }  from './internal/setImm
  * @static
  * @memberOf module:Utils
  * @method
- * @alias setImmediate
  * @category Util
  * @param {Function} callback - The function to call on a later loop around
  * the event loop. Invoked with (args...).

--- a/lib/setImmediate.js
+++ b/lib/setImmediate.js
@@ -12,7 +12,6 @@ import setImmediate from './internal/setImmediate';
  * @static
  * @memberOf module:Utils
  * @method
- * @alias nextTick
  * @category Util
  * @param {Function} callback - The function to call on a later loop around
  * the event loop. Invoked with (args...).

--- a/support/jsdoc/jsdoc-custom.js
+++ b/support/jsdoc/jsdoc-custom.js
@@ -115,6 +115,15 @@ $(function initSearchBar() {
         }
     });
 
+    $('.toc-method-alias').click(function() {
+        // highlighting should automatically be added by scrollspy
+        var $el = $(this);
+
+        var href = $el.find('a').eq(0).attr('href');
+        var $nonAlias = $('.is-selectable').find('a[href="'+href+'"]');
+        $('#toc').animate({ scrollTop: $nonAlias.parent().get(0).offsetTop - $el.offset().top + 50 }, 250);
+    });
+
     function fixOldHash() {
         var hash = window.location.hash;
         if (hash) {

--- a/support/jsdoc/jsdoc-fix-html.js
+++ b/support/jsdoc/jsdoc-fix-html.js
@@ -95,7 +95,7 @@ function scrollSpyFix($page, $nav) {
     $ul.addClass('nav').addClass('methods');
     $ul.find('.methods').each(function() {
         var $methodsList = $(this);
-        var $methods = $methodsList.find('[data-type="method"]');
+        var $methods = $methodsList.find('[data-type^="method"]');
         var $parentLi = $methodsList.parent();
 
         $methodsList.remove();
@@ -104,8 +104,6 @@ function scrollSpyFix($page, $nav) {
         $parentLi.addClass('toc-header');
 
     });
-
-    $page.find('[data-type="method"]').addClass("toc-method");
 
     $page.find('[id^="."]').each(function() {
         var $ele = $(this);

--- a/support/jsdoc/theme/publish.js
+++ b/support/jsdoc/theme/publish.js
@@ -307,10 +307,29 @@ function buildMemberNav(items, itemHeading, itemsSeen, linktoFn) {
                 itemsNav += '<li>' + linktoFn(item.longname, item.name.replace(/^module:/, ''));
                 if (methods.length) {
                     itemsNav += "<ul class='methods'>";
+                    var tocMethods = [];
+                    methods.forEach(function(method) {
+                        tocMethods.push({
+                            name: method.name,
+                            link: linkto(method.longname, method.name),
+                            isAlias: false
+                        });
+                        if (method.alias) {
+                            tocMethods.push({
+                                name: method.alias,
+                                link: linkto(method.longname, method.alias+ ` (${method.name})`),
+                                isAlias: true
+                            });
+                        }
+                    });
 
-                    methods.forEach(function (method) {
-                        itemsNav += "<li data-type='method'>";
-                        itemsNav += linkto(method.longname, method.name);
+                    sortStrs(tocMethods, 'name').forEach(function(method) {
+                        if (method.isAlias) {
+                            itemsNav += "<li data-type='method-alias' class='toc-method toc-method-alias'>";
+                        } else {
+                            itemsNav += "<li data-type='method' class='toc-method is-selectable'>";
+                        }
+                        itemsNav += method.link;
                         itemsNav += "</li>";
                     });
 
@@ -388,14 +407,24 @@ function buildNav(members) {
 }
 
 /**
-    Sorts an array of strings alphabetically
-    @param {Array<String>} strArr - Array of strings to sort
+    Sorts an array of strings or objects with a string property alphabetically
+    @param {Array<String>} strArr - Array to sort
+    @param {String} [objPropName] - The name of the string property on the
+        object to sort by
     @return {Array<String>} The sorted array
  */
-function sortStrs(strArr) {
-    return strArr.sort(function(s1, s2) {
-        var lowerCaseS1 = s1.toLowerCase();
-        var lowerCaseS2 = s2.toLowerCase();
+function sortStrs(arr, objPropName) {
+    return arr.sort(function(s1, s2) {
+        var lowerCaseS1,
+            lowerCaseS2;
+
+        if (objPropName) {
+            var lowerCaseS1 = s1[objPropName].toLowerCase();
+            var lowerCaseS2 = s2[objPropName].toLowerCase();
+        } else {
+            var lowerCaseS1 = s1.toLowerCase();
+            var lowerCaseS2 = s2.toLowerCase();
+        }
 
         if (lowerCaseS1 < lowerCaseS2) {
             return -1;

--- a/support/jsdoc/theme/static/styles/jsdoc-default.css
+++ b/support/jsdoc/theme/static/styles/jsdoc-default.css
@@ -172,11 +172,24 @@ section, h1 {
 #toc > .methods > .toc-method > a.active {
     padding: 0px 0px 0px 20px;
     border-left: 1px solid #D8DCDF;
-    color: #98999A;
 }
 
-#toc > .methods > .toc-method.active {
+#toc > .methods > .toc-method-alias > a {
+    font-size: 12px;
+    font-style: italic;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    color: #C0C0C0;
+}
+
+#toc > .methods > .is-selectable.active {
     background-color: #E8E8E8;
+}
+
+#toc > .methods > .is-selectable > a,
+#toc > .methods > .is-selectable > a.active {
+    color: #98999A;
 }
 
 .nav.navbar-right .navbar-form {


### PR DESCRIPTION
I styled the aliases slightly differently in the toc so there's a clearer distinction. I just wanted a second opinion because it seems like a good idea, but I don't know if it adds unnecessary clutter to the toc. 
![image](https://cloud.githubusercontent.com/assets/7647696/21079190/8015a778-bf57-11e6-857b-3d5ef76f50c4.png)
We already have the aliases documented in the body, and in searching.

Also, initially, it was highlighting both the alias and actual method when you clicked on an alias (due to scrollspy), which seemed weird. I changed it to just scroll the toc to the actual method, but I'm still not sure if that's the expected behaviour. Thoughts on that? The live version is on http://hargasinski.github.io/async/docs.html

Thanks in advance!