### PR TITLE
Print the name of the actual missing dependency in `async.auto`

### DIFF
--- a/lib/auto.js
+++ b/lib/auto.js
@@ -137,7 +137,8 @@ export default function (tasks, concurrency, callback) {
         arrayEach(dependencies, function (dependencyName) {
             if (!tasks[dependencyName]) {
                 throw new Error('async.auto task `' + key +
-                    '` has a non-existent dependency in ' +
+                    '` has a non-existent dependency `' +
+                    dependencyName + '` in ' +
                     dependencies.join(', '));
             }
             addListener(dependencyName, function () {

--- a/mocha_test/auto.js
+++ b/mocha_test/auto.js
@@ -286,7 +286,7 @@ describe('auto', function () {
                     callback(null, 'task1');
                 }]
             });
-        }).to.throw();
+        }).to.throw(/dependency `noexist`/);
         done();
     });
 


### PR DESCRIPTION
Hi, I'm not sure if there were specific guidelines to go through before submitting a PR, so apologies if I've missed a step. Now on to the PR:

We've been making use of `async.autoInject` as a light dependency injection framework, and whenever we'd make a mistake in a tasks dependencies we'd end up with a time-consuming task to track down what dependency `async` was failing on, because the error message wasn't giving enough to go on.

This PR simply adds the actual failed dependency to the error message to trivialize the work of tracking down missing dependencies.