### PR TITLE
standardize detect, every, and some implementations to use doParallel & equivalents

### DIFF
--- a/lib/detect.js
+++ b/lib/detect.js
@@ -1,7 +1,7 @@
 import identity from 'lodash/identity';
 
 import createTester from './internal/createTester';
-import eachOf from './eachOf';
+import doParallel from './internal/doParallel';
 import findGetResult from './internal/findGetResult';
 
 /**
@@ -39,4 +39,4 @@ import findGetResult from './internal/findGetResult';
  *     // result now equals the first file in the list that exists
  * });
  */
-export default createTester(eachOf, identity, findGetResult);
+export default doParallel(createTester(identity, findGetResult));

--- a/lib/detectLimit.js
+++ b/lib/detectLimit.js
@@ -1,7 +1,7 @@
 import identity from 'lodash/identity';
 
 import createTester from './internal/createTester';
-import eachOfLimit from './eachOfLimit';
+import doParallelLimit from './internal/doParallelLimit';
 import findGetResult from './internal/findGetResult';
 
 /**
@@ -26,4 +26,4 @@ import findGetResult from './internal/findGetResult';
  * (iteratee) or the value `undefined` if none passed. Invoked with
  * (err, result).
  */
-export default createTester(eachOfLimit, identity, findGetResult);
+export default doParallelLimit(createTester(identity, findGetResult));

--- a/lib/detectSeries.js
+++ b/lib/detectSeries.js
@@ -1,8 +1,5 @@
-import identity from 'lodash/identity';
-
-import createTester from './internal/createTester';
-import eachOfSeries from './eachOfSeries';
-import findGetResult from './internal/findGetResult';
+import detectLimit from './detectLimit';
+import doLimit from './internal/doLimit';
 
 /**
  * The same as [`detect`]{@link module:Collections.detect} but runs only a single async operation at a time.
@@ -24,4 +21,4 @@ import findGetResult from './internal/findGetResult';
  * (iteratee) or the value `undefined` if none passed. Invoked with
  * (err, result).
  */
-export default createTester(eachOfSeries, identity, findGetResult);
+export default doLimit(detectLimit, 1);

--- a/lib/eachOf.js
+++ b/lib/eachOf.js
@@ -1,5 +1,6 @@
 import isArrayLike from 'lodash/isArrayLike';
 
+import breakLoop from './internal/breakLoop';
 import eachOfLimit from './eachOfLimit';
 import doLimit from './internal/doLimit';
 import noop from 'lodash/noop';
@@ -16,10 +17,10 @@ function eachOfArrayLike(coll, iteratee, callback) {
         callback(null);
     }
 
-    function iteratorCallback(err) {
+    function iteratorCallback(err, value) {
         if (err) {
             callback(err);
-        } else if (++completed === length) {
+        } else if ((++completed === length) || value === breakLoop) {
             callback(null);
         }
     }

--- a/lib/every.js
+++ b/lib/every.js
@@ -1,5 +1,5 @@
 import createTester from './internal/createTester';
-import eachOf from './eachOf';
+import doParallel from './internal/doParallel';
 import notId from './internal/notId';
 
 /**
@@ -30,4 +30,4 @@ import notId from './internal/notId';
  *     // if result is true then every file exists
  * });
  */
-export default createTester(eachOf, notId, notId);
+export default doParallel(createTester(notId, notId));

--- a/lib/everyLimit.js
+++ b/lib/everyLimit.js
@@ -1,5 +1,5 @@
 import createTester from './internal/createTester';
-import eachOfLimit from './eachOfLimit';
+import doParallelLimit from './internal/doParallelLimit';
 import notId from './internal/notId';
 
 /**
@@ -22,4 +22,4 @@ import notId from './internal/notId';
  * `iteratee` functions have finished. Result will be either `true` or `false`
  * depending on the values of the async tests. Invoked with (err, result).
  */
-export default createTester(eachOfLimit, notId, notId);
+export default doParallelLimit(createTester(notId, notId));

--- a/lib/internal/createTester.js
+++ b/lib/internal/createTester.js
@@ -1,37 +1,29 @@
-'use strict';
 import noop from 'lodash/noop';
 import breakLoop from './breakLoop';
 
-export default function _createTester(eachfn, check, getResult) {
-    return function(arr, limit, iteratee, cb) {
-        function done() {
-            if (cb) {
-                cb(null, getResult(false));
-            }
-        }
-        function wrappedIteratee(x, _, callback) {
-            if (!cb) return callback();
-            iteratee(x, function (err, v) {
-                // Check cb as another iteratee may have resolved with a
-                // value or error since we started this iteratee
-                if (cb && (err || check(v))) {
-                    if (err) cb(err);
-                    else cb(err, getResult(true, x));
-                    cb = iteratee = false;
-                    callback(err, breakLoop);
+export default function _createTester(check, getResult) {
+    return function(eachfn, arr, iteratee, cb) {
+        cb = cb || noop;
+        var testPassed = false;
+        var testResult;
+        eachfn(arr, function(value, _, callback) {
+            iteratee(value, function(err, result) {
+                if (err) {
+                    callback(err);
+                } else if (check(result) && !testResult) {
+                    testPassed = true;
+                    testResult = getResult(true, value);
+                    callback(null, breakLoop);
                 } else {
                     callback();
                 }
             });
-        }
-        if (arguments.length > 3) {
-            cb = cb || noop;
-            eachfn(arr, limit, wrappedIteratee, done);
-        } else {
-            cb = iteratee;
-            cb = cb || noop;
-            iteratee = limit;
-            eachfn(arr, wrappedIteratee, done);
-        }
+        }, function(err) {
+            if (err) {
+                cb(err);
+            } else {
+                cb(null, testPassed ? testResult : getResult(false));
+            }
+        });
     };
 }

--- a/lib/some.js
+++ b/lib/some.js
@@ -1,5 +1,5 @@
 import createTester from './internal/createTester';
-import eachOf from './eachOf';
+import doParallel from './internal/doParallel';
 import identity from 'lodash/identity';
 
 /**
@@ -32,4 +32,4 @@ import identity from 'lodash/identity';
  *     // if result is true then at least one of the files exists
  * });
  */
-export default createTester(eachOf, Boolean, identity);
+export default doParallel(createTester(Boolean, identity));

--- a/lib/someLimit.js
+++ b/lib/someLimit.js
@@ -1,5 +1,5 @@
 import createTester from './internal/createTester';
-import eachOfLimit from './eachOfLimit';
+import doParallelLimit from './internal/doParallelLimit';
 import identity from 'lodash/identity';
 
 /**
@@ -23,4 +23,4 @@ import identity from 'lodash/identity';
  * Result will be either `true` or `false` depending on the values of the async
  * tests. Invoked with (err, result).
  */
-export default createTester(eachOfLimit, Boolean, identity);
+export default doParallelLimit(createTester(Boolean, identity));


### PR DESCRIPTION
Most functions in `async` that have `*Series` & `*Limit` versions use `doParallel`, `doParallelLimit` and `doLimit` in their implementation. This PR modifies `internal/createrTester` to be compatible with those functions, which allows `detect`, `every`, and `some` to follow the same pattern.