### PR TITLE
[waterfall] allow optional arguments defined in tasks

### DIFF
--- a/lib/waterfall.js
+++ b/lib/waterfall.js
@@ -80,9 +80,12 @@ export default  function(tasks, callback) {
             nextTask(args);
         }));
 
-        args.push(taskCallback);
-
         var task = tasks[taskIndex++];
+        // calc space between task arguments
+        var space = task.length - args.length - 1;
+        // fill the space with undefined
+        if (space > 0) args = args.concat(new Array(space));
+        args.push(taskCallback);
         task.apply(null, args);
     }
 

--- a/mocha_test/waterfall.js
+++ b/mocha_test/waterfall.js
@@ -56,6 +56,15 @@ describe("waterfall", function () {
         ]);
     });
 
+    it('optional arguments', function (done) {
+        async.waterfall([
+            function (callback) { callback(null, 1, 2); },
+            // here a=1, b=2
+            // c, d is optional
+            function (a, b, c, d, callback) { callback(); done(); }
+        ]);
+    });
+
     it('async', function(done){
         var call_order = [];
         async.waterfall([


### PR DESCRIPTION
I'm encountered the problem, that allow callback passing less arguments, and `nextTask` still work as expected.

This will not break existing code, but is a feature of flexibility.
