### PR TITLE
Make async.transform actually support 2 arguments

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -50,7 +50,7 @@ import once from './internal/once';
  * })
  */
 export default function transform (coll, accumulator, iteratee, callback) {
-    if (arguments.length === 3) {
+    if (arguments.length <= 3) {
         callback = iteratee;
         iteratee = accumulator;
         accumulator = isArray(coll) ? [] : {};

--- a/mocha_test/filter.js
+++ b/mocha_test/filter.js
@@ -172,4 +172,17 @@ describe("reject", function () {
         });
     });
 
+    it('filter fails', function(done) {
+        async.filter({a: 1, b: 2, c: 3}, function (item, callback) {
+            if (item === 3) {
+                callback("error", false);
+            } else {
+                callback(null, true);
+            }
+        }, function (err, res) {
+            expect(err).to.equal("error");
+            expect(res).to.equal(undefined);
+            done();
+        })
+    });
 });

--- a/mocha_test/transform.js
+++ b/mocha_test/transform.js
@@ -51,4 +51,15 @@ describe('transform', function() {
             done();
         });
     });
+
+    it('transform with two arguments', function(done) {
+        try {
+            async.transform([1, 2, 3], function (a, v, k, callback) {
+                callback();
+            });
+            done();
+        } catch (e) {
+            expect.fail();
+        }
+    });
 });


### PR DESCRIPTION
The documentation suggests that both the `accumulator` and `callback` arguments to transform is optional. 
(https://caolan.github.io/async/docs.html#transform) 

However, if both are left out (and transform therefore is called with only 2 arguments), transform crashes with a `iteratee is not a function` exception. 

By changing the equality check to a less than check, the transform function support the use-case where only 2 arguments are passed. 