### PR TITLE
Add a hint to `reflect` in the documentation of `parallel`

### DIFF
--- a/lib/parallel.js
+++ b/lib/parallel.js
@@ -13,6 +13,8 @@ import parallel from './internal/parallel';
  * any I/O, they will actually be executed in series.  Any synchronous setup
  * sections for each task will happen one after the other.  JavaScript remains
  * single-threaded.
+ * **Hint:** Use [`reflect`]{@link module:Utils.reflect} to continue the
+ * execution of other tasks when a task fails.
  *
  * It is also possible to use an object instead of an array. Each property will
  * be run as a function and the results will be passed to the final `callback`


### PR DESCRIPTION
How to continue *parallel* processing in case of a failing task seems to be a frequently asked question. It was mentioned in several issues:

- https://github.com/caolan/async/issues/334
- https://github.com/caolan/async/issues/675
- https://github.com/caolan/async/issues/798
- https://github.com/caolan/async/issues/942

Adding a hint to the documentation might help users of the library to find out about the answer to this question.