### PR TITLE
Added ability to pass initial params to asyncify

### DIFF
--- a/lib/asyncify.js
+++ b/lib/asyncify.js
@@ -1,5 +1,4 @@
-import isObject from 'lodash/isObject';
-import initialParams from './internal/initialParams';
+import isObject from 'lodash/isObject'
 
 /**
  * Take a sync function and make it async, passing its return value to a

--- a/lib/asyncify.js
+++ b/lib/asyncify.js
@@ -58,8 +58,12 @@ import initialParams from './internal/initialParams';
  * q.push(files);
  */
 export default function asyncify(func) {
-    return initialParams(function (args, callback) {
+    var initialArgs = Array.prototype.slice.call(arguments, 1);
+    return function () {
         var result;
+        var additionalArgs = Array.prototype.slice.call(arguments);
+        var callback = additionalArgs.pop();
+        var args = [].concat(initialArgs, additionalArgs);
         try {
             result = func.apply(this, args);
         } catch (e) {
@@ -75,5 +79,5 @@ export default function asyncify(func) {
         } else {
             callback(null, result);
         }
-    });
+    };
 }


### PR DESCRIPTION
Modifies the behavior of `async/asyncify` to match `async/apply`: we can now pass additional *initial* arguments to `asyncify` and those will be prepended to the *real* function call.