### PR TITLE
[asyncify] Make errors in callbacks throw globally

### DIFF
--- a/lib/asyncify.js
+++ b/lib/asyncify.js
@@ -1,5 +1,6 @@
 import isObject from 'lodash/isObject';
 import initialParams from './internal/initialParams';
+import setImmediate from './internal/setImmediate';
 
 /**
  * Take a sync function and make it async, passing its return value to a
@@ -68,12 +69,24 @@ export default function asyncify(func) {
         // if result is Promise object
         if (isObject(result) && typeof result.then === 'function') {
             result.then(function(value) {
-                callback(null, value);
+                invokeCallback(callback, null, value);
             }, function(err) {
-                callback(err.message ? err : new Error(err));
+                invokeCallback(callback, err.message ? err : new Error(err));
             });
         } else {
             callback(null, result);
         }
     });
+}
+
+function invokeCallback(callback, error, value) {
+    try {
+        callback(error, value);
+    } catch (e) {
+        setImmediate(rethrow, e);
+    }
+}
+
+function rethrow(error) {
+    throw error;
 }


### PR DESCRIPTION
If asyncify wraps a function returning promises, the callback will be executed as part of the promise’s `.then()` method.
This means that any error thrown from that method will be silenced, and lead to a “unhandled promise rejection” warning in modern engines.

Usually, we want these errors to be visible, and even crash the process.

I’d like to add a test, but there doesn’t seem to be a good way to do it, especially for both node.js and browsers.