### PR TITLE
Allow functions wrapped in `timeout` to be called multiple times (fixes #1418)

### DIFF
--- a/lib/timeout.js
+++ b/lib/timeout.js
@@ -43,33 +43,32 @@ import wrapAsync from './internal/wrapAsync';
  * });
  */
 export default function timeout(asyncFn, milliseconds, info) {
-    var originalCallback, timer;
-    var timedOut = false;
-
-    function injectedCallback() {
-        if (!timedOut) {
-            originalCallback.apply(null, arguments);
-            clearTimeout(timer);
-        }
-    }
-
-    function timeoutCallback() {
-        var name = asyncFn.name || 'anonymous';
-        var error  = new Error('Callback function "' + name + '" timed out.');
-        error.code = 'ETIMEDOUT';
-        if (info) {
-            error.info = info;
-        }
-        timedOut = true;
-        originalCallback(error);
-    }
-
     var fn = wrapAsync(asyncFn);
 
-    return initialParams(function (args, origCallback) {
-        originalCallback = origCallback;
+    return initialParams(function (args, callback) {
+        var timedOut = false;
+        var timer;
+
+        function timeoutCallback() {
+            var name = asyncFn.name || 'anonymous';
+            var error  = new Error('Callback function "' + name + '" timed out.');
+            error.code = 'ETIMEDOUT';
+            if (info) {
+                error.info = info;
+            }
+            timedOut = true;
+            callback(error);
+        }
+
+        args.push(function () {
+            if (!timedOut) {
+                callback.apply(null, arguments);
+                clearTimeout(timer);
+            }
+        });
+
         // setup timer and call original function
         timer = setTimeout(timeoutCallback, milliseconds);
-        fn.apply(null, args.concat(injectedCallback));
+        fn.apply(null, args);
     });
 }

--- a/mocha_test/timeout.js
+++ b/mocha_test/timeout.js
@@ -69,4 +69,40 @@ describe('timeout', function () {
             done();
         });
     });
+
+    it('timeout with multiple calls (#1418)', function(done) {
+        var timeout = async.timeout(function asyncFn(n, callback) {
+            if (n < 1) {
+                setTimeout(function() {
+                    callback(null, 'I will time out');
+                }, 75);
+            } else {
+                async.setImmediate(function() {
+                    callback(null, 'I didn\'t time out');
+                })
+            }
+        }, 50);
+
+        async.series([
+            function(cb) {
+                timeout(0, function(err, result) {
+                    expect(err.message).to.equal('Callback function "asyncFn" timed out.');
+                    expect(err.code).to.equal('ETIMEDOUT');
+                    expect(err.info).to.equal(undefined);
+                    expect(result).to.equal(undefined);
+                    cb();
+                });
+            },
+            function(cb) {
+                timeout(1, function(err, result) {
+                    expect(err).to.equal(null);
+                    expect(result).to.equal('I didn\'t time out');
+                    cb();
+                });
+            }
+        ], function(err) {
+            expect(err).to.equal(null);
+            done();
+        });
+    })
 });


### PR DESCRIPTION
Previously, the scoping of the `timedOut` variable in `timeout` meant that if any call to wrapped function timed out, any subsequent calls would also give a `ETIMEDOUT` error. This PR fixes that by moving the variables down one scope, so they are reinitialized each call. As a side benefit, it also lets the wrapped function be passed to functions such as `async.forEach`.