### PR TITLE
may be it's better to use the length method

### DIFF
--- a/mocha_test/queue.js
+++ b/mocha_test/queue.js
@@ -459,7 +459,7 @@ describe('queue', function(){
         }, 5);
 
         setTimeout(function () {
-            expect(q._tasks.length).to.equal(1);
+            expect(q.length()).to.equal(1);
             expect(q.running()).to.equal(2);
             q.resume();
         }, 15);


### PR DESCRIPTION
According to code in queue.js
``` javascript
length: function () {
     return q._tasks.length;
}
```
It may be better to use `q.length()` rather than `q._tasks.length`
