### PR TITLE
added rateLimit parameter to the queue

### DIFF
--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -78,5 +78,5 @@ import queue from './internal/queue';
  * });
  */
 export default function cargo(worker, payload) {
-    return queue(worker, 1, payload);
+    return queue(worker, 1, null, payload);
 }

--- a/lib/internal/queue.js
+++ b/lib/internal/queue.js
@@ -7,7 +7,7 @@ import setImmediate from './setImmediate';
 import DLL from './DoublyLinkedList';
 import wrapAsync from './wrapAsync';
 
-export default function queue(worker, concurrency, payload) {
+export default function queue(worker, concurrency, rateLimit, payload) {
     if (concurrency == null) {
         concurrency = 1;
     }
@@ -15,9 +15,26 @@ export default function queue(worker, concurrency, payload) {
         throw new Error('Concurrency must not be zero');
     }
 
+    if (typeof rateLimit === 'number' && rateLimit <= 0) {
+        throw new Error('rateLimit must greater than zero');
+    }
+
     var _worker = wrapAsync(worker);
     var numRunning = 0;
     var workersList = [];
+    var tokens = 0;
+    var interval = null;
+
+    // add tokens to the token count at the given rateLimit
+    if (rateLimit) {
+        tokens = (rateLimit > 1)? rateLimit : 1;
+        interval = setInterval(function() {
+            if (tokens < 1) {
+                tokens += rateLimit;
+            }
+            q.process();
+        }, 1000);
+    }
 
     function _insert(data, insertAtFront, callback) {
         if (callback != null && typeof callback !== 'function') {
@@ -97,6 +114,11 @@ export default function queue(worker, concurrency, payload) {
         kill: function () {
             q.drain = noop;
             q._tasks.empty();
+            if (interval) {
+                clearInterval(interval);
+                interval = null;
+            }
+            
         },
         unshift: function (data, callback) {
             _insert(data, true, callback);
@@ -111,7 +133,7 @@ export default function queue(worker, concurrency, payload) {
                 return;
             }
             isProcessing = true;
-            while(!q.paused && numRunning < q.concurrency && q._tasks.length){
+            while(!q.paused && numRunning < q.concurrency && q._tasks.length && (!rateLimit || (rateLimit && tokens >= 1))) {
                 var tasks = [], data = [];
                 var l = q._tasks.length;
                 if (q.payload) l = Math.min(l, q.payload);
@@ -134,6 +156,10 @@ export default function queue(worker, concurrency, payload) {
 
                 var cb = onlyOnce(_next(tasks));
                 _worker(data, cb);
+                if (rateLimit) {
+                    tokens--;
+                }
+                
             }
             isProcessing = false;
         },

--- a/lib/priorityQueue.js
+++ b/lib/priorityQueue.js
@@ -22,15 +22,19 @@ import queue from './queue';
  * @param {number} concurrency - An `integer` for determining how many `worker`
  * functions should be run in parallel.  If omitted, the concurrency defaults to
  * `1`.  If the concurrency is `0`, an error is thrown.
+* @param {number} [rateLimit=null] - A `number` that determines the maximum number
+ * of times per second work will be consumed from the queue.  If omitted, the rateLimit
+ * defaults to `1` - 1 item per second.  If the rateLimit is `0` or less, an error is thrown.
+ * A rate limit of `null` means "no rate limit - as fast as possible"
  * @returns {module:ControlFlow.QueueObject} A priorityQueue object to manage the tasks. There are two
  * differences between `queue` and `priorityQueue` objects:
  * * `push(task, priority, [callback])` - `priority` should be a number. If an
  *   array of `tasks` is given, all tasks will be assigned the same priority.
  * * The `unshift` method was removed.
  */
-export default function(worker, concurrency) {
+export default function(worker, concurrency, rateLimit) {
     // Start with a normal queue
-    var q = queue(worker, concurrency);
+    var q = queue(worker, concurrency, rateLimit);
 
     // Override push to accept second parameter representing priority
     q.push = function(data, priority, callback) {

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -72,6 +72,10 @@ import wrapAsync from './internal/wrapAsync';
  * @param {number} [concurrency=1] - An `integer` for determining how many
  * `worker` functions should be run in parallel.  If omitted, the concurrency
  * defaults to `1`.  If the concurrency is `0`, an error is thrown.
+ * @param {number} [rateLimit=null] - A `number` that determines the maximum number
+ * of times per second work will be consumed from the queue.  If omitted, the rateLimit
+ * defaults to `1` - 1 item per second.  If the rateLimit is `0` or less, an error is thrown.
+ * A rate limit of `null` means "no rate limit - as fast as possible"
  * @returns {module:ControlFlow.QueueObject} A queue object to manage the tasks. Callbacks can
  * attached as certain properties to listen for specific events during the
  * lifecycle of the queue.
@@ -106,9 +110,10 @@ import wrapAsync from './internal/wrapAsync';
  *     console.log('finished processing bar');
  * });
  */
-export default function (worker, concurrency) {
+export default function (worker, concurrency, rateLimit) {
+    if (typeof rateLimit != 'number') rateLimit = null;
     var _worker = wrapAsync(worker);
     return queue(function (items, cb) {
         _worker(items[0], cb);
-    }, concurrency, 1);
+    }, concurrency, rateLimit, 1);
 }


### PR DESCRIPTION
I'm a heavy user of `async.queue`, but if I am using it to queue calls to an API service which implements rate limiting (say 5 API calls per second), it becomes very tricky to get the queue to consume the queue within the rate limits.

To fix this, I branched the code and added a new parameter to the queue object:

```js
var worker = function(data, done) {
  setTimeout(done, 100);
};
var concurrency = 1;
var rateLimit = 5;
var q = async.queue(worker, concurrency, rateLimit);
```

The queue works as normal but only proceeds at a maximum rate of 5 items per second. 

The existing tests all pass and supplying a rateLimit of `null` or leaving it as undefined keeps the original queue unchanged. 

I've added a test for the rate-limited version.

(as this is my first commit to this project, I'm not sure if I should be including the "dist" files in the PR - please let me know if you would like these included too).
