### PR TITLE
ensure q.workersList() contains items being processed [fixes #1428]

### DIFF
--- a/lib/internal/queue.js
+++ b/lib/internal/queue.js
@@ -53,11 +53,13 @@ export default function queue(worker, concurrency, payload) {
         return function(err){
             numRunning -= 1;
 
+
             for (var i = 0, l = tasks.length; i < l; i++) {
                 var task = tasks[i];
+
                 var index = indexOf(workersList, task, 0);
                 if (index >= 0) {
-                    workersList.splice(index)
+                    workersList.splice(index, 1);
                 }
 
                 task.callback.apply(task, arguments);
@@ -118,11 +120,11 @@ export default function queue(worker, concurrency, payload) {
                 for (var i = 0; i < l; i++) {
                     var node = q._tasks.shift();
                     tasks.push(node);
+                    workersList.push(node);
                     data.push(node.data);
                 }
 
                 numRunning += 1;
-                workersList.push(tasks[0]);
 
                 if (q._tasks.length === 0) {
                     q.empty();

--- a/lib/internal/queue.js
+++ b/lib/internal/queue.js
@@ -53,7 +53,6 @@ export default function queue(worker, concurrency, payload) {
         return function(err){
             numRunning -= 1;
 
-
             for (var i = 0, l = tasks.length; i < l; i++) {
                 var task = tasks[i];
 

--- a/mocha_test/queue.js
+++ b/mocha_test/queue.js
@@ -759,16 +759,19 @@ describe('queue', function(){
                 expect(
                     getWorkersListData(q)
                 ).to.eql(itemsBeingProcessed[task]);
+                expect(q.workersList().length).to.equal(q.running());
                 async.setImmediate(function() {
                     expect(
                         getWorkersListData(q)
                     ).to.eql(itemsBeingProcessed[task+'_cb']);
+                    expect(q.workersList().length).to.equal(q.running());
                     cb();
                 });
             }, 2);
 
             q.drain = function() {
                 expect(q.workersList()).to.eql([]);
+                expect(q.workersList().length).to.equal(q.running());
                 done();
             };
 

--- a/mocha_test/queue.js
+++ b/mocha_test/queue.js
@@ -656,7 +656,7 @@ describe('queue', function(){
         });
     });
 
-    context('q.unsaturated(): ',function() {
+    context('q.unsaturated(): ', function() {
         it('should have a default buffer property that equals 25% of the concurrenct rate', function(done){
             var calls = [];
             var q = async.queue(function(task, cb) {
@@ -719,6 +719,65 @@ describe('queue', function(){
         });
     });
 
+    context('workersList', function() {
+        it('should be the same length as running()', function(done) {
+            var q = async.queue(function(task, cb) {
+                async.setImmediate(function() {
+                    expect(q.workersList().length).to.equal(q.running());
+                    cb();
+                });
+            }, 2);
+
+            q.drain = function() {
+                expect(q.workersList().length).to.equal(0);
+                expect(q.running()).to.equal(0);
+                done();
+            };
+
+            q.push('foo');
+            q.push('bar');
+            q.push('baz');
+        });
+
+        it('should contain the items being processed', function(done) {
+            var itemsBeingProcessed = {
+                'foo': ['foo'],
+                'foo_cb': ['foo', 'bar'],
+                'bar': ['foo', 'bar'],
+                'bar_cb': ['bar', 'baz'],
+                'baz': ['bar', 'baz'],
+                'baz_cb': ['baz']
+            };
+
+            function getWorkersListData(q) {
+                return q.workersList().map(function(v) {
+                    return v.data;
+                });
+            }
+
+            var q = async.queue(function(task, cb) {
+                expect(
+                    getWorkersListData(q)
+                ).to.eql(itemsBeingProcessed[task]);
+                async.setImmediate(function() {
+                    expect(
+                        getWorkersListData(q)
+                    ).to.eql(itemsBeingProcessed[task+'_cb']);
+                    cb();
+                });
+            }, 2);
+
+            q.drain = function() {
+                expect(q.workersList()).to.eql([]);
+                done();
+            };
+
+            q.push('foo');
+            q.push('bar');
+            q.push('baz');
+        });
+    })
+
     it('remove', function(done) {
         var result = [];
         var q = async.queue(function(data, cb) {
@@ -738,4 +797,3 @@ describe('queue', function(){
         }
     });
 });
-


### PR DESCRIPTION
Aligns `q.workersList()` and `cargo.workersList()` with the [docs](https://caolan.github.io/async/docs.html#QueueObject).

`workersList()` is not really relevant in the context of `async.cargo`, as there will only be 1 worker running at a given time, but I would prefer to keep the behavior consistent between it and `queue`.