### PR TITLE
Use shift instead of splice (when possible) in queue

### DIFF
--- a/lib/internal/queue.js
+++ b/lib/internal/queue.js
@@ -65,7 +65,9 @@ export default function queue(worker, concurrency, payload) {
                 var task = tasks[i];
 
                 var index = indexOf(workersList, task, 0);
-                if (index >= 0) {
+                if (index === 0) {
+                    workersList.shift();
+                } else if (index > 0) {
                     workersList.splice(index, 1);
                 }
 


### PR DESCRIPTION
Hi,

I had some performance issues when using `async.cargo` with large number of tasks (batches of 10k). Changing `splice(0, 1)` to `shift()` improved it dramatically (for a batch of 10k it removed ~3 seconds from each batch). 
For some reason I wasn't able to reproduce it using an example. Maybe it depends on the memory state of the process. From a simple [benchmark](https://jsperf.com/remove-first-element-from-array/4) here you can see shift is much faster than splice (I checked on Safari, Chrome & Firefox on MacOS)