### PR TITLE
Fix NPE when err is undefined

### DIFF
--- a/lib/asyncify.js
+++ b/lib/asyncify.js
@@ -71,7 +71,7 @@ export default function asyncify(func) {
             result.then(function(value) {
                 invokeCallback(callback, null, value);
             }, function(err) {
-                invokeCallback(callback, err.message ? err : new Error(err));
+                invokeCallback(callback, err && err.message ? err : new Error(err));
             });
         } else {
             callback(null, result);


### PR DESCRIPTION
Fixes:
```
TypeError: Cannot read property 'message' of undefined
```