### PR TITLE
Add monthly npm download badge and link to graph of downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Join the chat at https://gitter.im/caolan/async](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/caolan/async?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![libhive - Open source examples](https://www.libhive.com/providers/npm/packages/async/examples/badge.svg)](https://www.libhive.com/providers/npm/packages/async)
 [![jsDelivr Hits](https://data.jsdelivr.com/v1/package/npm/async/badge?style=rounded)](https://www.jsdelivr.com/package/npm/async)
+[![NPM monthly downloads](https://img.shields.io/npm/dm/async.svg)](https://npmcharts.com/compare/async?minimal=true)
 
 
 Async is a utility module which provides straight-forward, powerful functions for working with [asynchronous JavaScript](http://caolan.github.io/async/global.html). Although originally designed for use with [Node.js](https://nodejs.org/) and installable via `npm install --save async`, it can also be used directly in the browser.


### PR DESCRIPTION
Hi! I was wondering if you might not mind having a monthly npm download badge (60M/month) and link it to a [chart of historic daily downloads](https://npmcharts.com/compare/async?minimal=true)?

If not, feel free to close and apologies for the drive-by PR 😄