### PR TITLE
Optimize the library for webpack users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,10 @@ $(BUILD_ES)/package.json: package.json
 	mkdir -p "$(@D)"
 	support/sync-es-package.js > $@
 
+$(BUILD_ES)/README.md: README.es.md
+	mkdir -p "$(@D)"
+	cp $< $@
+
 $(BUILD_ES)/%: %
 	mkdir -p "$(@D)"
 	cp $< $@

--- a/README.es.md
+++ b/README.es.md
@@ -19,7 +19,7 @@ For Documentation, visit <https://caolan.github.io/async/>
 
 ```javascript
 // for use with callbacks...
-import { forEachFor } from "async-es";
+import { forEachOf } from "async-es";
 
 const images = {cat: "/cat.png", dog: "/dog.png", duck: "/duck.png"};
 const sizes = {};

--- a/README.es.md
+++ b/README.es.md
@@ -10,7 +10,7 @@
 
 Async is a utility module which provides straight-forward, powerful functions for working with [asynchronous JavaScript](http://caolan.github.io/async/global.html). Although originally designed for use with [Node.js](https://nodejs.org/) and installable via `npm install --save async`, it can also be used directly in the browser.
 
-This version of the package is optimized for the Node.js environment. If you use Async with webpack, install [`async-es`](https://www.npmjs.com/package/async-es) instead.
+This version of the package is optimized for building with webpack. If you use Async in Node.js, install [`async`](https://www.npmjs.com/package/async) instead.
 
 For Documentation, visit <https://caolan.github.io/async/>
 
@@ -18,34 +18,37 @@ For Documentation, visit <https://caolan.github.io/async/>
 
 
 ```javascript
-// for use with Node-style callbacks...
-var async = require("async");
+// for use with callbacks...
+import { forEachFor } from "async-es";
 
-var obj = {dev: "/dev.json", test: "/test.json", prod: "/prod.json"};
-var configs = {};
+const images = {cat: "/cat.png", dog: "/dog.png", duck: "/duck.png"};
+const sizes = {};
 
-async.forEachOf(obj, (value, key, callback) => {
-    fs.readFile(__dirname + value, "utf8", (err, data) => {
-        if (err) return callback(err);
-        try {
-            configs[key] = JSON.parse(data);
-        } catch (e) {
-            return callback(e);
-        }
+forEachOf(images, (value, key, callback) => {
+    const imageElem = new Image();
+    imageElem.src = value;
+    imageElem.addEventListener("load", () => {
+        sizes[key] = {
+            width: imageElem.naturalWidth,
+            height: imageElem.naturalHeight,
+        };
         callback();
+    });
+    imageElem.addEventListener("error", (e) => {
+        callback(e);
     });
 }, err => {
     if (err) console.error(err.message);
-    // configs is now a map of JSON data
-    doSomethingWith(configs);
+    // `sizes` is now a map of image sizes
+    doSomethingWith(sizes);
 });
 ```
 
 ```javascript
-var async = require("async");
+import { mapLimit } from "async-es";
 
 // ...or ES2017 async functions
-async.mapLimit(urls, 5, async function(url) {
+mapLimit(urls, 5, async function(url) {
     const response = await fetch(url)
     return response.body
 }, (err, results) => {

--- a/support/sync-es-package.js
+++ b/support/sync-es-package.js
@@ -5,6 +5,7 @@ var json = JSON.parse(fs.readFileSync(__dirname + "/../package.json"), "utf8");
 
 json.name = "async-es";
 json.main = "index.js";
+json.sideEffects = false;
 delete json.dependencies["lodash"];
 
 process.stdout.write(JSON.stringify(json, null, 2));


### PR DESCRIPTION
Hey there! I optimized the library for users who build their browser apps with webpack. [webpack](https://github.com/webpack/webpack) is super-popular in front-end development, so that should be a large percent of browser users.

In my tests with `map`/`parallel` methods, the library size dropped from 28 to 12 minified kB (−57%). Here’s the repo if you want to reproduce: [iamakulov/async-optimization-repro](https://github.com/iamakulov/async-optimization-repro)

_This is a part of my performance consulting. I help open-source projects (for free) and companies (for money) to optimize the performance of their products: [iamakulov.com/perf-consulting](https://iamakulov.com/pages/perf-consulting/)_

---

**The problem**
Right now, when you import `async` into the app, you import all the methods it includes. So even if you only want to use `.map`, your app receives all 78 `async` methods:

```js
import async from 'async';
async.map(...);
// All other methods are present at `async`, even if you don’t need them
```

Usually, this is solved by importing only the necessary methods:

```js
import { map } from 'async';
map(...);
```

However, in case with `async`, this doesn’t help because the `async`’s entry point, `dist/async.js`, is a bundle with all the library’s code.

Right now, there’s no easy solution to this problem except doing `import map from 'async/map'`, but that’s not very obvious.

**The solution**
I added a few flags that hint webpack how to optimize the library:

- Added `"module": "lib/index.js"` into `package.json`
When the `module` field is present, webpack uses it instead of `main` to determine the entry point into the lib. With `module`, webpack would consume ES modules and drop unused code [with tree shaking](https://webpack.js.org/guides/tree-shaking/).

- Added `"sideEffects": false` into `package.json`
`sideEffects: false` tells webpack that library modules don’t have any side effects (e.g., don’t modify any globals). Webpack uses this info to remove the module if it’s reexported but not used. This improves the effect of tree-shaking.

- Removed `lib` from `.npmignore`
Webpack users would need this directory, so we’ll need to publish it to npm.
This has a drawback – the module would get larger and take longer to install – but, as a benefit, browser users would spend less time downloading it. Browser downloads happen more often than npm installs, so I believe this is for good.

- Documented the browser usage in readme. Docs are located at http://caolan.github.io/async/, but I’ve thought the performance considerations are important enough to place the snippet in the readme (many users won’t get into docs far enough to read it there). If you don’t want this change, I’d be happy to move it elsewhere.

(Sorry for ads in the beginning, I do freelancing for living)