### PR TITLE
Fix a memoize test case

### DIFF
--- a/test/memoize.js
+++ b/test/memoize.js
@@ -125,9 +125,9 @@ describe("memoize", function() {
             expect(err).to.equal(testerr);
             testerr = null;
 
-            memoized(5, 6, function (err, result) {
+            memoized(1, 3, function (err, result) {
                 expect(err).to.equal(null);
-                expect(result).to.equal(11);
+                expect(result).to.equal(4);
                 done();
             });
         });


### PR DESCRIPTION
It is related to https://github.com/caolan/async/pull/1466

I realized that the test case doesn't test the changes.

The function memoizes the results using the first argument by default.
So `5` is the different key, memo won't be used. :)