### PR TITLE
feat: Canceling flows

### DIFF
--- a/intro.md
+++ b/intro.md
@@ -175,7 +175,7 @@ async.map([1, 2, 3], AsyncSquaringLibrary.square.bind(AsyncSquaringLibrary), fun
 
 ### Subtle Memory Leaks
 
-There are cases where you might want to exit early from async flow, when calling an Async method insice another async function:
+There are cases where you might want to exit early from async flow, when calling an Async method inside another async function:
 
 ```javascript
 function myFunction (args, outerCallback) {

--- a/lib/auto.js
+++ b/lib/auto.js
@@ -102,6 +102,7 @@ export default function (tasks, concurrency, callback) {
 
     var results = {};
     var runningTasks = 0;
+    var canceled = false;
     var hasError = false;
 
     var listeners = Object.create(null);
@@ -156,7 +157,7 @@ export default function (tasks, concurrency, callback) {
     }
 
     function processQueue() {
-        if (readyTasks.length === 0 && runningTasks === 0) {
+        if (readyTasks.length === 0 && runningTasks === 0 && !canceled) {
             return callback(null, results);
         }
         while(readyTasks.length && runningTasks < concurrency) {
@@ -189,6 +190,10 @@ export default function (tasks, concurrency, callback) {
 
         var taskCallback = onlyOnce(function(err, result) {
             runningTasks--;
+            if (err === false) {
+                canceled = true
+                return
+            }
             if (arguments.length > 2) {
                 result = slice(arguments, 1);
             }
@@ -200,7 +205,7 @@ export default function (tasks, concurrency, callback) {
                 safeResults[key] = result;
                 hasError = true;
                 listeners = Object.create(null);
-
+                if (canceled) return
                 callback(err, safeResults);
             } else {
                 results[key] = result;

--- a/lib/auto.js
+++ b/lib/auto.js
@@ -157,7 +157,8 @@ export default function (tasks, concurrency, callback) {
     }
 
     function processQueue() {
-        if (readyTasks.length === 0 && runningTasks === 0 && !canceled) {
+        if (canceled) return
+        if (readyTasks.length === 0 && runningTasks === 0) {
             return callback(null, results);
         }
         while(readyTasks.length && runningTasks < concurrency) {

--- a/lib/doDuring.js
+++ b/lib/doDuring.js
@@ -30,6 +30,7 @@ export default function doDuring(fn, test, callback) {
 
     function next(err/*, ...args*/) {
         if (err) return callback(err);
+        if (err === false) return;
         var args = slice(arguments, 1);
         args.push(check);
         _test.apply(this, args);
@@ -37,6 +38,7 @@ export default function doDuring(fn, test, callback) {
 
     function check(err, truth) {
         if (err) return callback(err);
+        if (err === false) return;
         if (!truth) return callback(null);
         _fn(next);
     }

--- a/lib/doWhilst.js
+++ b/lib/doWhilst.js
@@ -31,6 +31,7 @@ export default function doWhilst(iteratee, test, callback) {
     var _iteratee = wrapAsync(iteratee);
     var next = function(err/*, ...args*/) {
         if (err) return callback(err);
+        if (err === false) return;
         var args = slice(arguments, 1);
         if (test.apply(this, args)) return _iteratee(next);
         callback.apply(null, [null].concat(args));

--- a/lib/during.js
+++ b/lib/during.js
@@ -45,11 +45,13 @@ export default function during(test, fn, callback) {
 
     function next(err) {
         if (err) return callback(err);
+        if (err === false) return;
         _test(check);
     }
 
     function check(err, truth) {
         if (err) return callback(err);
+        if (err === false) return;
         if (!truth) return callback(null);
         _fn(next);
     }

--- a/lib/eachOf.js
+++ b/lib/eachOf.js
@@ -12,12 +12,17 @@ function eachOfArrayLike(coll, iteratee, callback) {
     callback = once(callback || noop);
     var index = 0,
         completed = 0,
-        length = coll.length;
+        length = coll.length,
+        canceled = false;
     if (length === 0) {
         callback(null);
     }
 
     function iteratorCallback(err, value) {
+        if (err === false) {
+            canceled = true
+        }
+        if (canceled === true) return
         if (err) {
             callback(err);
         } else if ((++completed === length) || value === breakLoop) {

--- a/lib/forever.js
+++ b/lib/forever.js
@@ -38,6 +38,7 @@ export default function forever(fn, errback) {
 
     function next(err) {
         if (err) return done(err);
+        if (err === false) return;
         task(next);
     }
     next();

--- a/lib/internal/eachOfLimit.js
+++ b/lib/internal/eachOfLimit.js
@@ -19,8 +19,9 @@ export default function _eachOfLimit(limit) {
         var looping = false;
 
         function iterateeCallback(err, value) {
+            if (canceled) return
             running -= 1;
-            if (err && !canceled) {
+            if (err) {
                 done = true;
                 callback(err);
             }
@@ -30,7 +31,6 @@ export default function _eachOfLimit(limit) {
             }
             else if (value === breakLoop || (done && running <= 0)) {
                 done = true;
-                if (canceled) return
                 return callback(null);
             }
             else if (!looping) {
@@ -44,7 +44,7 @@ export default function _eachOfLimit(limit) {
                 var elem = nextElem();
                 if (elem === null) {
                     done = true;
-                    if (running <= 0 && !canceled) {
+                    if (running <= 0) {
                         callback(null);
                     }
                     return;

--- a/lib/internal/eachOfLimit.js
+++ b/lib/internal/eachOfLimit.js
@@ -14,17 +14,23 @@ export default function _eachOfLimit(limit) {
         }
         var nextElem = iterator(obj);
         var done = false;
+        var canceled = false;
         var running = 0;
         var looping = false;
 
         function iterateeCallback(err, value) {
             running -= 1;
-            if (err) {
+            if (err && !canceled) {
                 done = true;
                 callback(err);
             }
+            else if (err === false) {
+                done = true;
+                canceled = true;
+            }
             else if (value === breakLoop || (done && running <= 0)) {
                 done = true;
+                if (canceled) return
                 return callback(null);
             }
             else if (!looping) {
@@ -38,7 +44,7 @@ export default function _eachOfLimit(limit) {
                 var elem = nextElem();
                 if (elem === null) {
                     done = true;
-                    if (running <= 0) {
+                    if (running <= 0 && !canceled) {
                         callback(null);
                     }
                     return;

--- a/lib/retry.js
+++ b/lib/retry.js
@@ -133,6 +133,7 @@ export default function retry(opts, task, callback) {
     var attempt = 1;
     function retryAttempt() {
         _task(function(err) {
+            if (err === false) return
             if (err && attempt++ < options.times &&
                 (typeof options.errorFilter != 'function' ||
                     options.errorFilter(err))) {

--- a/lib/tryEach.js
+++ b/lib/tryEach.js
@@ -52,7 +52,7 @@ export default function tryEach(tasks, callback) {
                 result = res;
             }
             error = err;
-            callback(!err);
+            callback(err ? null : {});
         });
     }, function () {
         callback(error, result);

--- a/lib/waterfall.js
+++ b/lib/waterfall.js
@@ -67,7 +67,6 @@ export default  function(tasks, callback) {
     if (!Array.isArray(tasks)) return callback(new Error('First argument to waterfall must be an array of functions'));
     if (!tasks.length) return callback();
     var taskIndex = 0;
-    var canceled = false
 
     function nextTask(args) {
         var task = wrapAsync(tasks[taskIndex++]);

--- a/lib/waterfall.js
+++ b/lib/waterfall.js
@@ -67,6 +67,7 @@ export default  function(tasks, callback) {
     if (!Array.isArray(tasks)) return callback(new Error('First argument to waterfall must be an array of functions'));
     if (!tasks.length) return callback();
     var taskIndex = 0;
+    var canceled = false
 
     function nextTask(args) {
         var task = wrapAsync(tasks[taskIndex++]);
@@ -75,7 +76,10 @@ export default  function(tasks, callback) {
     }
 
     function next(err/*, ...args*/) {
-        if (err === false) return // canceled
+        if (err === false || canceled) {
+            canceled = true
+            return
+        }
         if (err || taskIndex === tasks.length) {
             return callback.apply(null, arguments);
         }

--- a/lib/waterfall.js
+++ b/lib/waterfall.js
@@ -75,6 +75,7 @@ export default  function(tasks, callback) {
     }
 
     function next(err/*, ...args*/) {
+        if (err === null) return // canceled
         if (err || taskIndex === tasks.length) {
             return callback.apply(null, arguments);
         }

--- a/lib/waterfall.js
+++ b/lib/waterfall.js
@@ -76,10 +76,7 @@ export default  function(tasks, callback) {
     }
 
     function next(err/*, ...args*/) {
-        if (err === false || canceled) {
-            canceled = true
-            return
-        }
+        if (err === false) return
         if (err || taskIndex === tasks.length) {
             return callback.apply(null, arguments);
         }

--- a/lib/waterfall.js
+++ b/lib/waterfall.js
@@ -75,7 +75,7 @@ export default  function(tasks, callback) {
     }
 
     function next(err/*, ...args*/) {
-        if (err === null) return // canceled
+        if (err === false) return // canceled
         if (err || taskIndex === tasks.length) {
             return callback.apply(null, arguments);
         }

--- a/lib/whilst.js
+++ b/lib/whilst.js
@@ -44,6 +44,7 @@ export default function whilst(test, iteratee, callback) {
     if (!test()) return callback(null);
     var next = function(err/*, ...args*/) {
         if (err) return callback(err);
+        if (err === false) return;
         if (test()) return _iteratee(next);
         var args = slice(arguments, 1);
         callback.apply(null, [null].concat(args));

--- a/test/auto.js
+++ b/test/auto.js
@@ -184,7 +184,7 @@ describe('auto', function () {
                 callback('testerror2');
             }
         },
-        function(err){
+        function(){
             throw new Error('should not get here')
         });
         setTimeout(() => {

--- a/test/auto.js
+++ b/test/auto.js
@@ -168,6 +168,31 @@ describe('auto', function () {
         setTimeout(done, 100);
     });
 
+    it('auto canceled', function(done){
+        const call_order = []
+        async.auto({
+            task1: function(callback){
+                call_order.push(1)
+                callback(false);
+            },
+            task2: ['task1', function(/*results, callback*/){
+                call_order.push(2)
+                throw new Error('task2 should not be called');
+            }],
+            task3: function(callback){
+                call_order.push(3)
+                callback('testerror2');
+            }
+        },
+        function(err){
+            throw new Error('should not get here')
+        });
+        setTimeout(() => {
+            expect(call_order).to.eql([1, 3])
+            done()
+        }, 10);
+    });
+
     it('auto no callback', function(done){
         async.auto({
             task1: function(callback){callback();},

--- a/test/auto.js
+++ b/test/auto.js
@@ -193,6 +193,38 @@ describe('auto', function () {
         }, 10);
     });
 
+    it('does not start other tasks when it has been canceled', function(done) {
+        const call_order = []
+        debugger
+        async.auto({
+            task1: function(callback) {
+                call_order.push(1);
+                // defer calling task2, so task3 has time to stop execution
+                async.setImmediate(callback);
+            },
+            task2: ['task1', function( /*results, callback*/ ) {
+                call_order.push(2);
+                throw new Error('task2 should not be called');
+            }],
+            task3: function(callback) {
+                call_order.push(3);
+                callback(false);
+            },
+            task4: ['task3', function( /*results, callback*/ ) {
+                call_order.push(4);
+                throw new Error('task4 should not be called');
+            }]
+        },
+        function() {
+            throw new Error('should not get here')
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql([1, 3])
+            done()
+        }, 25)
+    });
+
     it('auto no callback', function(done){
         async.auto({
             task1: function(callback){callback();},

--- a/test/auto.js
+++ b/test/auto.js
@@ -210,7 +210,7 @@ describe('auto', function () {
     it('auto error should pass partial results', function(done) {
         async.auto({
             task1: function(callback){
-                callback(false, 'result1');
+                callback(null, 'result1');
             },
             task2: ['task1', function(results, callback){
                 callback('testerror', 'result2');

--- a/test/during.js
+++ b/test/during.js
@@ -34,6 +34,22 @@ describe('during', function() {
         );
     });
 
+    it('during canceling', (done) => {
+        let counter = 0;
+        async.during(
+            cb => cb(null, true),
+            cb => {
+                counter++
+                cb(counter === 2 ? false : null);
+            },
+            () => { throw new Error('should not get here')}
+        );
+        setTimeout(() => {
+            expect(counter).to.equal(2);
+            done();
+        }, 10)
+    })
+
     it('doDuring', function(done) {
         var call_order = [];
 
@@ -95,4 +111,36 @@ describe('during', function() {
             }
         );
     });
+
+    it('doDuring canceling', (done) => {
+        let counter = 0;
+        async.doDuring(
+            cb => {
+                counter++
+                cb(counter === 2 ? false : null);
+            },
+            cb => cb(null, true),
+            () => { throw new Error('should not get here')}
+        );
+        setTimeout(() => {
+            expect(counter).to.equal(2);
+            done();
+        }, 10)
+    })
+
+    it('doDuring canceling in test', (done) => {
+        let counter = 0;
+        async.doDuring(
+            cb => {
+                counter++
+                cb(null, counter);
+            },
+            (n, cb) => cb(n === 2 ? false : null, true),
+            () => { throw new Error('should not get here')}
+        );
+        setTimeout(() => {
+            expect(counter).to.equal(2);
+            done();
+        }, 10)
+    })
 });

--- a/test/eachOf.js
+++ b/test/eachOf.js
@@ -414,7 +414,7 @@ describe("eachOf", function() {
                 return callback(false);
             }
             callback()
-        }, function(err){
+        }, function(){
             throw new Error('should not get here')
         });
         setTimeout(() => {
@@ -435,7 +435,7 @@ describe("eachOf", function() {
                 }
                 callback()
             })
-        }, function(err){
+        }, function(){
             throw new Error('should not get here')
         });
         setTimeout(() => {
@@ -459,7 +459,7 @@ describe("eachOf", function() {
                 }
                 callback()
             })
-        }, function(err){
+        }, function(){
             throw new Error('should not get here')
         });
         setTimeout(() => {

--- a/test/eachOf.js
+++ b/test/eachOf.js
@@ -403,4 +403,69 @@ describe("eachOf", function() {
             done();
         });
     });
+
+    it('forEachOfLimit canceled', function(done) {
+        var obj = { a: 1, b: 2, c: 3, d: 4, e: 5 };
+        var call_order = [];
+
+        async.forEachOfLimit(obj, 3, function(value, key, callback){
+            call_order.push(value, key);
+            if (value === 2) {
+                return callback(false);
+            }
+            callback()
+        }, function(err){
+            throw new Error('should not get here')
+        });
+        setTimeout(() => {
+            expect(call_order).to.eql([ 1, "a", 2, "b" ]);
+            done()
+        }, 10);
+    });
+
+    it('forEachOfLimit canceled (async)', function(done) {
+        var obj = { a: 1, b: 2, c: 3, d: 4, e: 5 };
+        var call_order = [];
+
+        async.forEachOfLimit(obj, 3, function(value, key, callback){
+            call_order.push(value, key);
+            setTimeout(() => {
+                if (value === 2) {
+                    return callback(false);
+                }
+                callback()
+            })
+        }, function(err){
+            throw new Error('should not get here')
+        });
+        setTimeout(() => {
+            expect(call_order).to.eql([ 1, "a", 2, "b", 3, "c", 4, "d" ]);
+            done()
+        }, 20);
+    });
+
+    it('forEachOfLimit canceled (async, w/ error)', function(done) {
+        var obj = { a: 1, b: 2, c: 3, d: 4, e: 5 };
+        var call_order = [];
+
+        async.forEachOfLimit(obj, 3, function(value, key, callback){
+            call_order.push(value, key);
+            setTimeout(() => {
+                if (value === 2) {
+                    return callback(false);
+                }
+                if (value === 3) {
+                    return callback('fail');
+                }
+                callback()
+            })
+        }, function(err){
+            throw new Error('should not get here')
+        });
+        setTimeout(() => {
+            expect(call_order).to.eql([ 1, "a", 2, "b", 3, "c", 4, "d" ]);
+            done()
+        }, 20);
+    });
+
 });

--- a/test/eachOf.js
+++ b/test/eachOf.js
@@ -444,6 +444,28 @@ describe("eachOf", function() {
         }, 20);
     });
 
+
+    it('forEachOfLimit canceled (async, array)', function(done) {
+        var obj = ['a', 'b', 'c', 'd', 'e'];
+        var call_order = [];
+
+        async.eachOfLimit(obj, 3, function(value, key, callback){
+            call_order.push(key, value);
+            setTimeout(() => {
+                if (value === 'b') {
+                    return callback(false);
+                }
+                callback()
+            })
+        }, function(){
+            throw new Error('should not get here')
+        });
+        setTimeout(() => {
+            expect(call_order).to.eql([ 0, "a", 1, "b", 2, "c", 3, "d" ]);
+            done()
+        }, 20);
+    });
+
     it('forEachOfLimit canceled (async, w/ error)', function(done) {
         var obj = { a: 1, b: 2, c: 3, d: 4, e: 5 };
         var call_order = [];

--- a/test/eachOf.js
+++ b/test/eachOf.js
@@ -444,8 +444,7 @@ describe("eachOf", function() {
         }, 20);
     });
 
-
-    it('forEachOfLimit canceled (async, array)', function(done) {
+    it('eachOfLimit canceled (async, array)', function(done) {
         var obj = ['a', 'b', 'c', 'd', 'e'];
         var call_order = [];
 
@@ -462,6 +461,27 @@ describe("eachOf", function() {
         });
         setTimeout(() => {
             expect(call_order).to.eql([ 0, "a", 1, "b", 2, "c", 3, "d" ]);
+            done()
+        }, 20);
+    });
+
+    it('eachOf canceled (async, array)', function(done) {
+        var arr = ['a', 'b', 'c', 'd', 'e'];
+        var call_order = [];
+
+        async.eachOf(arr, function(value, key, callback){
+            call_order.push(key, value);
+            setTimeout(() => {
+                if (value === 'b') {
+                    return callback(false);
+                }
+                callback()
+            })
+        }, function(){
+            throw new Error('should not get here')
+        });
+        setTimeout(() => {
+            expect(call_order).to.eql([ 0, "a", 1, "b", 2, "c", 3, "d", 4, "e" ]);
             done()
         }, 20);
     });

--- a/test/forever.js
+++ b/test/forever.js
@@ -49,7 +49,7 @@ describe('forever', function(){
             setTimeout(() => {
                 expect(counter).to.eql(2)
                 done()
-            })
+            }, 10)
         })
     });
 });

--- a/test/forever.js
+++ b/test/forever.js
@@ -38,5 +38,18 @@ describe('forever', function(){
                 done();
             });
         });
+
+        it('should cancel', (done) => {
+            var counter = 0;
+            async.forever(cb => {
+                counter++
+                cb(counter === 2 ? false : null)
+            }, () => { throw new Error('should not get here') })
+
+            setTimeout(() => {
+                expect(counter).to.eql(2)
+                done()
+            })
+        })
     });
 });

--- a/test/parallel.js
+++ b/test/parallel.js
@@ -191,6 +191,32 @@ describe('parallel', function() {
         });
     });
 
+    it('parallel limit canceled', function(done) {
+        const call_order = []
+        async.parallelLimit([
+            function(callback){
+                call_order.push(1)
+                callback();
+            },
+            function(callback){
+                call_order.push(2)
+                callback(false);
+            },
+            function(callback){
+                call_order.push(3)
+                callback('error', 2);
+            }
+        ],
+        1,
+        function(err){
+            throw new Error('should not get here')
+        });
+        setTimeout(() => {
+            expect(call_order).to.eql([1, 2]);
+            done()
+        }, 25);
+    });
+
     it('parallel call in another context @nycinvalid @nodeonly', function(done) {
         var vm = require('vm');
         var sandbox = {

--- a/test/parallel.js
+++ b/test/parallel.js
@@ -208,7 +208,7 @@ describe('parallel', function() {
             }
         ],
         1,
-        function(err){
+        function(){
             throw new Error('should not get here')
         });
         setTimeout(() => {

--- a/test/retry.js
+++ b/test/retry.js
@@ -119,7 +119,7 @@ describe("retry", function () {
         setTimeout(function () {
             expect(calls).to.equal(5);
             done();
-        }, 10);
+        }, 50);
     });
 
     it("should be cancelable", function (done) {

--- a/test/retry.js
+++ b/test/retry.js
@@ -119,7 +119,19 @@ describe("retry", function () {
         setTimeout(function () {
             expect(calls).to.equal(5);
             done();
-        }, 50);
+        }, 10);
+    });
+
+    it("should be cancelable", function (done) {
+        var calls = 0;
+        async.retry(2, function(cb) {
+            calls++;
+            cb(calls > 1 ? false : 'fail');
+        }, () => { throw new Error('should not get here') });
+        setTimeout(function () {
+            expect(calls).to.equal(2);
+            done();
+        }, 10);
     });
 
     it('retry does not precompute the intervals (#1226)', function(done) {

--- a/test/until.js
+++ b/test/until.js
@@ -34,6 +34,22 @@ describe('until', function(){
         );
     });
 
+    it('until canceling', (done) => {
+        let counter = 0;
+        async.until(
+            () => false,
+            cb => {
+                counter++
+                cb(counter === 2 ? false: null);
+            },
+            () => { throw new Error('should not get here')}
+        );
+        setTimeout(() => {
+            expect(counter).to.equal(2);
+            done();
+        }, 10)
+    })
+
     it('doUntil', function(done) {
         var call_order = [];
         var count = 0;
@@ -92,4 +108,20 @@ describe('until', function(){
             }
         );
     });
+
+    it('doUntil canceling', (done) => {
+        let counter = 0;
+        async.doUntil(
+            cb => {
+                counter++
+                cb(counter === 2 ? false: null);
+            },
+            () => false,
+            () => { throw new Error('should not get here')}
+        );
+        setTimeout(() => {
+            expect(counter).to.equal(2);
+            done();
+        }, 10)
+    })
 });

--- a/test/waterfall.js
+++ b/test/waterfall.js
@@ -90,6 +90,28 @@ describe("waterfall", function () {
         });
     });
 
+
+    it('canceled', function(done){
+        const call_order = []
+        async.waterfall([
+            function(callback){
+                call_order.push(1)
+                callback(null);
+            },
+            function(callback){
+                call_order.push(2)
+                assert(false, 'next function should not be called');
+                callback();
+            }
+        ], function(err){
+            throw new Error('should not get here')
+        });
+        setTimeout(() => {
+            expect(call_order).to.eql([1])
+            done()
+        }, 10)
+    });
+
     it('multiple callback calls', function(){
         var arr = [
             function(callback){

--- a/test/waterfall.js
+++ b/test/waterfall.js
@@ -96,7 +96,7 @@ describe("waterfall", function () {
         async.waterfall([
             function(callback){
                 call_order.push(1)
-                callback(null);
+                callback(false);
             },
             function(callback){
                 call_order.push(2)

--- a/test/waterfall.js
+++ b/test/waterfall.js
@@ -153,9 +153,7 @@ describe("waterfall", function () {
             function(arg1, arg2, callback){
                 setTimeout(callback, 15, null, arg1, arg2, 'three');
             }
-        ], function () {
-            throw new Error('should not get here')
-        });
+        ]);
     });
 
     it('call in another context @nycinvalid @nodeonly', function(done) {

--- a/test/waterfall.js
+++ b/test/waterfall.js
@@ -103,7 +103,7 @@ describe("waterfall", function () {
                 assert(false, 'next function should not be called');
                 callback();
             }
-        ], function(err){
+        ], function(){
             throw new Error('should not get here')
         });
         setTimeout(() => {

--- a/test/whilst.js
+++ b/test/whilst.js
@@ -48,6 +48,22 @@ describe('whilst', function(){
         done();
     });
 
+    it('whilst canceling', function(done) {
+        var counter = 0;
+        async.whilst(
+            function () { return counter < 3; },
+            function (cb) {
+                counter++;
+                cb(counter === 2 ? false : null);
+            },
+            () => { throw new Error('should not get here')}
+        );
+        setTimeout(() => {
+            expect(counter).to.equal(2);
+            done();
+        }, 10)
+    });
+
     it('doWhilst', function(done) {
         var call_order = [];
 
@@ -122,4 +138,20 @@ describe('whilst', function(){
             }
         );
     });
+
+    it('doWhilst canceling', (done) => {
+        let counter = 0;
+        async.doWhilst(
+            cb => {
+                counter++
+                cb(counter === 2 ? false : null);
+            },
+            () => true,
+            () => { throw new Error('should not get here')}
+        );
+        setTimeout(() => {
+            expect(counter).to.equal(2);
+            done();
+        }, 10)
+    })
 });


### PR DESCRIPTION
Closes #1064 

This allows you to signal that you have exited early from an async flow by `callback(false)` --- calling back with `false` as the error.  All further callbacks will be ignored, and the final callback will not be called.  This is handy to avoid a subtle memory leak when you exit early.

- [x] `eachOfLimit` - based methods (e.g. all collection-based methods)
- [x] `compose`/`seq`
- [x] `waterfall`
- [x] `auto`/`autoInject`
- [x] `whilst`, `until`, and family
- [x] `forever`
- [ ] ?? (any I'm missing?)
- [x] Docs