### PR TITLE
add item except error happend.

### DIFF
--- a/lib/internal/map.js
+++ b/lib/internal/map.js
@@ -11,7 +11,9 @@ export default function _asyncMap(eachfn, arr, iteratee, callback) {
     return eachfn(arr, (value, _, iterCb) => {
         var index = counter++;
         _iteratee(value, (err, v) => {
-            results[index] = v;
+            if (!err) {
+                results[index] = v;
+            }
             iterCb(err);
         });
     }, err => {

--- a/lib/internal/parallel.js
+++ b/lib/internal/parallel.js
@@ -11,7 +11,9 @@ export default function _parallel(eachfn, tasks, callback) {
             if (result.length < 2) {
                 [result] = result;
             }
-            results[key] = result;
+            if (!err) {
+                results[key] = result;
+            }
             taskCb(err);
         });
     }, err => callback(err, results));


### PR DESCRIPTION
If error happened, the result with a undefined at last. For example dir2 is not exist.
`async.concat(['dir1','dir2'], fs.readdir, function(err, results) {
    // results is now an array of stats for each file
});`