### PR TITLE
Updated outdated documentation for Concat

### DIFF
--- a/lib/concat.js
+++ b/lib/concat.js
@@ -4,9 +4,8 @@ import concatLimit from './concatLimit';
 /**
  * Applies `iteratee` to each item in `coll`, concatenating the results. Returns
  * the concatenated list. The `iteratee`s are called in parallel, and the
- * results are concatenated as they return. There is no guarantee that the
- * results array will be returned in the original order of `coll` passed to the
- * `iteratee` function.
+ * results are concatenated as they return. The results array will be returned in
+ * the original order of `coll` passed to the `iteratee` function.
  *
  * @name concat
  * @static


### PR DESCRIPTION
Concat function, since v2.5.0, returns back array results in the original order.