### PR TITLE
--save no longer needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![jsDelivr Hits](https://data.jsdelivr.com/v1/package/npm/async/badge?style=rounded)](https://www.jsdelivr.com/package/npm/async)
 
 
-Async is a utility module which provides straight-forward, powerful functions for working with [asynchronous JavaScript](http://caolan.github.io/async/global.html). Although originally designed for use with [Node.js](https://nodejs.org/) and installable via `npm install --save async`, it can also be used directly in the browser.
+Async is a utility module which provides straight-forward, powerful functions for working with [asynchronous JavaScript](http://caolan.github.io/async/global.html). Although originally designed for use with [Node.js](https://nodejs.org/) and installable via `npm install async`, it can also be used directly in the browser.
 
 This version of the package is optimized for the Node.js environment. If you use Async with webpack, install [`async-es`](https://www.npmjs.com/package/async-es) instead.
 


### PR DESCRIPTION
`--save` is on by default as of [npm 5](https://blog.npmjs.org/post/161081169345/v500), so `npm install aphrodite` is functionally equivalent to `npm install --save aphrodite` now