### PR TITLE
Set focus on search input on page load

### DIFF
--- a/support/jsdoc/jsdoc-custom.js
+++ b/support/jsdoc/jsdoc-custom.js
@@ -113,7 +113,7 @@ $(() => {
                 location.hash = '#'+suggestion;
             }
         }
-    });
+    }).focus();
 
     function fixOldHash() {
         var {hash} = window.location;


### PR DESCRIPTION
Currently when docs page is loaded focus is not set on search input. So a user has to click on the input to type. It is not convenient. 

Although the input has `autofocus` attribute it gets ignored, because of typeahead. 

I tried and tested solution from [here](https://github.com/twitter/typeahead.js/issues/444). It helped