### PR TITLE
Reflects any values passed even if function has error

### DIFF
--- a/lib/reflect.js
+++ b/lib/reflect.js
@@ -44,14 +44,18 @@ export default function reflect(fn) {
     var _fn = wrapAsync(fn);
     return initialParams(function reflectOn(args, reflectCallback) {
         args.push((error, ...cbArgs) => {
+            let retVal = {};
             if (error) {
-                return reflectCallback(null, { error });
+                retVal.error = error;
             }
-            var value = cbArgs;
-            if (cbArgs.length <= 1) {
-                [value] = cbArgs
+            if (cbArgs.length > 0){
+                var value = cbArgs;
+                if (cbArgs.length <= 1) {
+                    [value] = cbArgs;
+                }
+                retVal.value = value;
             }
-            reflectCallback(null, { value });
+            reflectCallback(null, retVal);
         });
 
         return _fn.apply(this, args);

--- a/test/parallel.js
+++ b/test/parallel.js
@@ -248,14 +248,18 @@ describe('parallel', () => {
             }),
             async.reflect((callback) => {
                 callback(null, 2);
+            }),
+            async.reflect((callback) => {
+                callback('error3');
             })
         ],
         (err, results) => {
             assert(err === null, err + " passed instead of 'null'");
             expect(results).to.eql([
-                { error: 'error' },
-                { error: 'error2' },
-                { value: 2 }
+                { error: 'error', value: 1 },
+                { error: 'error2', value: 2 },
+                { value: 2 },
+                { error: 'error3' },
             ]);
             done();
         });
@@ -275,6 +279,11 @@ describe('parallel', () => {
                 setTimeout(() => {
                     callback(null, 'three');
                 }, 100);
+            },
+            four(callback) {
+                setTimeout(() => {
+                    callback('four', 4);
+                }, 100);
             }
         };
 
@@ -282,7 +291,8 @@ describe('parallel', () => {
             expect(results).to.eql({
                 one: { value: 'one' },
                 two: { error: 'two' },
-                three: { value: 'three' }
+                three: { value: 'three' },
+                four: { error: 'four', value: 4 }
             });
             done();
         })
@@ -300,21 +310,21 @@ describe('parallel', () => {
     it('parallel empty object with reflect all (errors)', (done) => {
         var tasks = {
             one(callback) {
-                callback('one');
+                callback('one', 1);
             },
             two(callback) {
                 callback('two');
             },
             three(callback) {
-                callback('three');
+                callback('three', 3);
             }
         };
 
         async.parallel(async.reflectAll(tasks), (err, results) => {
             expect(results).to.eql({
-                one: { error: 'one' },
+                one: { error: 'one', value: 1 },
                 two: { error: 'two' },
-                three: { error: 'three' }
+                three: { error: 'three', value: 3 }
             });
             done();
         })

--- a/test/series.js
+++ b/test/series.js
@@ -102,14 +102,18 @@ describe('series', () => {
             }),
             async.reflect((callback) => {
                 callback(null, 1);
+            }),
+            async.reflect((callback) => {
+                callback('error3');
             })
         ],
         (err, results) => {
             assert(err === null, err + " passed instead of 'null'");
             expect(results).to.eql([
-                { error: 'error' },
-                { error: 'error2' },
-                { value: 1 }
+                { error: 'error', value: 1 },
+                { error: 'error2', value: 2 },
+                { value: 1 },
+                { error: 'error3' },
             ]);
             done();
         });


### PR DESCRIPTION
reflect/reflectAll return any "value" passed even if function also passes error. Includes tests.

For example:

```
function myFunc(callback){
    return callback('my error, 'my fallback value')
}

async.parallel(reflectAll({
   myval: myFunc
}), function(err, r){
    // r.myval.error = 'my error'
    // r.myval.value = 'my fallback value'
});
```

Addresses Issue #1587