### PR TITLE
Fixes #1582

### DIFF
--- a/lib/concatLimit.js
+++ b/lib/concatLimit.js
@@ -26,7 +26,7 @@ function concatLimit(coll, limit, iteratee, callback) {
     return mapLimit(coll, limit, (val, iterCb) => {
         _iteratee(val, (err, ...args) => {
             if (err) return iterCb(err);
-            return iterCb(null, args);
+            return iterCb(err, args);
         });
     }, (err, mapResults) => {
         var result = [];

--- a/lib/groupByLimit.js
+++ b/lib/groupByLimit.js
@@ -27,7 +27,7 @@ function groupByLimit(coll, limit, iteratee, callback) {
     return mapLimit(coll, limit, (val, iterCb) => {
         _iteratee(val, (err, key) => {
             if (err) return iterCb(err);
-            return iterCb(null, {key, val});
+            return iterCb(err, {key, val});
         });
     }, (err, mapResults) => {
         var result = {};

--- a/lib/internal/createTester.js
+++ b/lib/internal/createTester.js
@@ -8,7 +8,7 @@ export default function _createTester(check, getResult) {
         const iteratee = wrapAsync(_iteratee)
         eachfn(arr, (value, _, callback) => {
             iteratee(value, (err, result) => {
-                if (err) return callback(err)
+                if (err || err === false) return callback(err);
 
                 if (check(result) && !testResult) {
                     testPassed = true;

--- a/lib/internal/filter.js
+++ b/lib/internal/filter.js
@@ -27,7 +27,7 @@ function filterGeneric(eachfn, coll, iteratee, callback) {
             if (v) {
                 results.push({index, value: x});
             }
-            iterCb();
+            iterCb(err);
         });
     }, err => {
         if (err) return callback(err);

--- a/lib/mapValuesLimit.js
+++ b/lib/mapValuesLimit.js
@@ -33,7 +33,7 @@ function mapValuesLimit(obj, limit, iteratee, callback) {
         _iteratee(val, key, (err, result) => {
             if (err) return next(err);
             newObj[key] = result;
-            next();
+            next(err);
         });
     }, err => callback(err, newObj));
 }

--- a/lib/sortBy.js
+++ b/lib/sortBy.js
@@ -55,7 +55,7 @@ function sortBy (coll, iteratee, callback) {
     return map(coll, (x, iterCb) => {
         _iteratee(x, (err, criteria) => {
             if (err) return iterCb(err);
-            iterCb(null, {value: x, criteria});
+            iterCb(err, {value: x, criteria});
         });
     }, (err, results) => {
         if (err) return callback(err);

--- a/lib/tryEach.js
+++ b/lib/tryEach.js
@@ -45,6 +45,8 @@ function tryEach(tasks, callback) {
     var result;
     return eachSeries(tasks, (task, taskCb) => {
         wrapAsync(task)((err, ...args) => {
+            if (err === false) return taskCb(err);
+
             if (args.length < 2) {
                 [result] = args;
             } else {

--- a/test/applyEach.js
+++ b/test/applyEach.js
@@ -35,6 +35,32 @@ describe('applyEach', () => {
         });
     });
 
+    it('applyEach canceled', (done) => {
+        var call_order = [];
+        function one(_, cb) {
+            call_order.push('one');
+            cb(null, 1);
+        }
+
+        function two(_, cb) {
+            call_order.push('two');
+            cb(false);
+        }
+
+        function three(/*, cb */) {
+            throw new Error('third task - should not get here');
+        }
+
+        async.applyEach({one, two, three}, 5, () => {
+            throw new Error('final callback - should not get here');
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql(['one', 'two']);
+            done();
+        }, 25);
+    });
+
     it('applyEachSeries', (done) => {
         var call_order = [];
         function one(val, cb) {
@@ -64,6 +90,33 @@ describe('applyEach', () => {
             expect(results).to.eql([1, 2, 3]);
             done();
         });
+    });
+
+    it('applyEachSeries canceled', (done) => {
+        var call_order = [];
+        function one(_, cb) {
+            async.setImmediate(() => {
+                call_order.push('one');
+                cb(null, 1);
+            });
+        }
+        function two(_, cb) {
+            async.setImmediate(() => {
+                call_order.push('two');
+                cb(false);
+            });
+        }
+        function three(/*, cb */) {
+            throw new Error('third task - should not get here');
+        }
+        async.applyEachSeries([one, two, three], 5, () => {
+            throw new Error('final callback - should not get here');
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql(['one', 'two']);
+            done();
+        }, 25);
     });
 
     it('applyEach partial application', (done) => {

--- a/test/autoInject.js
+++ b/test/autoInject.js
@@ -122,4 +122,30 @@ describe('autoInject', () => {
             done();
         });
     });
+
+    it('should be cancelable', (done) => {
+        var call_order = [];
+
+        async.autoInject({
+            task1 (cb) {
+                call_order.push('task1');
+                cb(null, 1);
+            },
+            task2 (task3, cb) {
+                call_order.push('task2');
+                cb(null, 2);
+            },
+            task3 (cb) {
+                call_order.push('task3');
+                cb(false);
+            },
+        }, () => {
+            throw new Error('should not get here');
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql(['task1', 'task3']);
+            done();
+        }, 25);
+    });
 });

--- a/test/compose.js
+++ b/test/compose.js
@@ -83,4 +83,29 @@ describe('compose', () => {
             done();
         });
     });
+
+    it('should be cancelable', (done) => {
+        var call_order = [];
+
+        var add2 = function (n, cb) {
+            call_order.push('add2');
+            cb(null, n + 2);
+        };
+        var mul3 = function (n, cb) {
+            call_order.push('mul3');
+            cb(false, n * 3);
+        };
+        var add1 = function () {
+            throw new Error('add1 - should not get here');
+        };
+        var add2mul3add1 = async.compose(add1, mul3, add2);
+        add2mul3add1(3, () => {
+            throw new Error('final callback - should not get here');
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql(['add2', 'mul3']);
+            done();
+        }, 25);
+    });
 });

--- a/test/concat.js
+++ b/test/concat.js
@@ -36,6 +36,24 @@ describe('concat', function() {
             });
         });
 
+        it('canceled', (done) => {
+            var callOrder = [];
+            async.concat([1, 3, 2], (val, next) => {
+                callOrder.push(val);
+                if (val === 3) {
+                    return next(false, [val, val + 1]);
+                }
+                next(null, [val, val + 1]);
+            }, () => {
+                throw new Error('should not get here');
+            });
+
+            setTimeout(() => {
+                expect(callOrder).to.eql([1, 3]);
+                done();
+            }, 25);
+        });
+
         it('original untouched', (done) => {
             var arr = ['foo', 'bar', 'baz'];
             async.concat(arr, (val, next) => {
@@ -240,6 +258,26 @@ describe('concat', function() {
             });
         });
 
+        it('canceled', (done) => {
+            var callOrder = [];
+            async.concatLimit([1, 2, 3, 4, 5], 2, (val, next) => {
+                callOrder.push(val);
+                async.setImmediate(() => {
+                    if (val === 3) {
+                        return next(false, val);
+                    }
+                    next(null, val)
+                });
+            }, () => {
+                throw new Error('should not get here');
+            });
+
+            setTimeout(() => {
+                expect(callOrder).to.eql([1, 2, 3, 4]);
+                done();
+            }, 50);
+        });
+
         it('handles objects', (done) => {
             async.concatLimit({'foo': 1, 'bar': 2, 'baz': 3}, 2, (val, next) => {
                 next(null, val+1);
@@ -371,6 +409,26 @@ describe('concat', function() {
                 expect(result).to.eql(['foo', 'foo']);
                 done();
             });
+        });
+
+        it('canceled', (done) => {
+            var callOrder = [];
+            async.concatSeries([1, 2, 3], (val, next) => {
+                callOrder.push(val);
+                async.setImmediate(() => {
+                    if (val === 2) {
+                        return next(false, val);
+                    }
+                    next(null, val)
+                });
+            }, () => {
+                throw new Error('should not get here');
+            });
+
+            setTimeout(() => {
+                expect(callOrder).to.eql([1, 2]);
+                done();
+            }, 50);
         });
 
         it('handles objects', (done) => {

--- a/test/detect.js
+++ b/test/detect.js
@@ -47,6 +47,24 @@ describe("detect", () => {
         });
     });
 
+    it('detect canceled', (done) => {
+        var call_order = [];
+        async.detect({'a': 3, 'b': 2, 'c': 1}, (x, callback) => {
+            call_order.push(x);
+            if (x === 2) {
+                return callback(false);
+            }
+            callback(null);
+        }, () => {
+            throw new Error('should not get here');
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql([3, 2]);
+            done();
+        }, 25);
+    });
+
     it('detectSeries', function(done){
         var call_order = [];
         async.detectSeries([3,2,1], detectIteratee.bind(this, call_order), (err, result) => {
@@ -98,6 +116,26 @@ describe("detect", () => {
         });
     });
 
+    it('detectSeries canceled', (done) => {
+        var call_order = [];
+        async.detectSeries([3, 2, 1], (x, callback) => {
+            async.setImmediate(() => {
+                call_order.push(x);
+                if (x === 2) {
+                    return callback(false);
+                }
+                callback(null);
+            });
+        }, () => {
+            throw new Error('should not get here');
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql([3, 2]);
+            done();
+        }, 50);
+    });
+
     it('detectLimit', function(done){
         var call_order = [];
         async.detectLimit([3, 2, 1], 2, detectIteratee.bind(this, call_order), (err, result) => {
@@ -133,6 +171,26 @@ describe("detect", () => {
             expect(result).to.equal(3);
             done();
         });
+    });
+
+    it('detectLimit canceled', (done) => {
+        var call_order = [];
+        async.detectLimit([3, 3, 2, 2, 1], 2, (x, callback) => {
+            async.setImmediate(() => {
+                call_order.push(x);
+                if (x === 2) {
+                    return callback(false);
+                }
+                callback(null);
+            });
+        }, () => {
+            throw new Error('should not get here');
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql([3, 3, 2, 2]);
+            done();
+        }, 50);
     });
 
     it('detectSeries doesn\'t cause stack overflow (#1293)', (done) => {

--- a/test/each.js
+++ b/test/each.js
@@ -74,6 +74,24 @@ describe("each", () => {
         setTimeout(done, 50);
     });
 
+    it('each canceled', (done) => {
+        var call_order = [];
+        async.each([1, 2, 3], (x, callback) => {
+            call_order.push(x);
+            if (x === 2) {
+                return callback(false);
+            }
+            callback(null);
+        }, () => {
+            throw new Error('should not get here');
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql([1, 2, 3]);
+            done();
+        }, 25);
+    });
+
     it('each no callback', function(done) {
         async.each([1], eachNoCallbackIteratee.bind(this, done));
     });
@@ -146,6 +164,26 @@ describe("each", () => {
             expect(err).to.equal('error');
         });
         setTimeout(done, 50);
+    });
+
+    it('eachSeries canceled', (done) => {
+        var call_order = [];
+        async.eachSeries([1, 2, 3], (x, callback) => {
+            call_order.push(x);
+            async.setImmediate(() => {
+                if (x === 2) {
+                    return callback(false);
+                }
+                callback(null);
+            });
+        }, () => {
+            throw new Error('should not get here');
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql([1, 2]);
+            done();
+        }, 50);
     });
 
     it('eachSeries no callback', function(done) {
@@ -224,6 +262,26 @@ describe("each", () => {
             expect(err).to.equal('error');
         });
         setTimeout(done, 25);
+    });
+
+    it('eachLimit canceled', (done) => {
+        var call_order = [];
+        async.eachLimit([1, 1, 2, 2, 3], 2, (x, callback) => {
+            call_order.push(x);
+            async.setImmediate(() => {
+                if (x === 2) {
+                    return callback(false);
+                }
+                callback(null);
+            });
+        }, () => {
+            throw new Error('should not get here');
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql([1, 1, 2, 2]);
+            done();
+        }, 50);
     });
 
     it('eachLimit no callback', function(done) {

--- a/test/every.js
+++ b/test/every.js
@@ -84,6 +84,23 @@ describe("every", () => {
         });
     });
 
+    it('canceled', (done) => {
+        var call_order = [];
+        async.every([1,2,3], (x, callback) => {
+            call_order.push(x);
+            if (x === 2) {
+                return callback(false, true);
+            }
+            callback(null, true);
+        }, () => {
+            throw new Error('should not get here');
+        });
+        setTimeout(() => {
+            expect(call_order).to.eql([1,2,3]);
+            done();
+        }, 25);
+    });
+
     it('everySeries doesn\'t cause stack overflow (#1293)', (done) => {
         var arr = _.range(10000);
         let calls = 0;
@@ -97,6 +114,25 @@ describe("every", () => {
         });
     });
 
+    it('everySeries canceled', (done) => {
+        var call_order = [];
+        async.everySeries([1,2,3], (x, callback) => {
+            call_order.push(x);
+            async.setImmediate(() => {
+                if (x === 2) {
+                    return callback(false, true);
+                }
+                callback(null, true);
+            });
+        }, () => {
+            throw new Error('should not get here');
+        });
+        setTimeout(() => {
+            expect(call_order).to.eql([1, 2]);
+            done();
+        }, 50);
+    });
+
     it('everyLimit doesn\'t cause stack overflow (#1293)', (done) => {
         var arr = _.range(10000);
         let calls = 0;
@@ -108,6 +144,25 @@ describe("every", () => {
             expect(calls).to.equal(100);
             done();
         });
+    });
+
+    it('everyLimit canceled', (done) => {
+        var call_order = [];
+        async.everyLimit([1,1,2,2,3], 2, (x, callback) => {
+            call_order.push(x);
+            async.setImmediate(() => {
+                if (x === 2) {
+                    return callback(false, true);
+                }
+                callback(null, true);
+            });
+        }, () => {
+            throw new Error('final callback - should not get here');
+        });
+        setTimeout(() => {
+            expect(call_order).to.eql([1,1,2,2]);
+            done();
+        }, 50);
     });
 
     it('all alias', () => {

--- a/test/filter.js
+++ b/test/filter.js
@@ -92,12 +92,50 @@ describe("filter", () => {
         });
     });
 
+    it('filter canceled', (done) => {
+        var call_order = [];
+        async.filter([3,1,2], (x, callback) => {
+            call_order.push(x);
+            if (x === 1) {
+                return callback(false, true);
+            }
+            callback(null, true);
+        } , () => {
+            throw new Error('should not get here');
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql([3,1,2]);
+            done();
+        }, 25);
+    });
+
     it('filterSeries', (done) => {
         async.filterSeries([3,1,2], filterIteratee, (err, results) => {
             expect(err).to.equal(null);
             expect(results).to.eql([3,1]);
             done();
         });
+    });
+
+    it('filterSeries canceled', (done) => {
+        var call_order = [];
+        async.filterSeries([3,1,2], (x, callback) => {
+            call_order.push(x);
+            async.setImmediate(() => {
+                if (x === 1) {
+                    return callback(false, true);
+                }
+                callback(null, true);
+            });
+        }, () => {
+            throw new Error('should not get here');
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql([3,1]);
+            done();
+        }, 50);
     });
 
     it('select alias', () => {
@@ -116,6 +154,26 @@ describe("filter", () => {
             expect(result).to.eql([5, 3, 1]);
             done();
         });
+    });
+
+    it('filterLimit canceled', (done) => {
+        var call_order = [];
+        async.filterLimit([1,1,2,2,3], 2, (x, callback) => {
+            call_order.push(x);
+            async.setImmediate(() => {
+                if (x === 2) {
+                    return callback(false, true);
+                }
+                callback(null, true);
+            });
+        }, () => {
+            throw new Error('should not get here');
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql([1,1,2,2]);
+            done();
+        }, 50);
     });
 
 });
@@ -152,12 +210,50 @@ describe("reject", () => {
         });
     });
 
+    it('reject canceled', (done) => {
+        var call_order = [];
+        async.filter([3,1,2], (x, callback) => {
+            call_order.push(x);
+            if (x === 2) {
+                return callback(false, false);
+            }
+            callback(null, false);
+        } , () => {
+            throw new Error('should not get here');
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql([3,1,2]);
+            done();
+        }, 25);
+    });
+
     it('rejectSeries', (done) => {
         async.rejectSeries([3,1,2], filterIteratee, (err, results) => {
             expect(err).to.equal(null);
             expect(results).to.eql([2]);
             done();
         });
+    });
+
+    it('rejectSeries canceled', (done) => {
+        var call_order = [];
+        async.rejectSeries([3,1,2], (x, callback) => {
+            call_order.push(x);
+            async.setImmediate(() => {
+                if (x === 1) {
+                    return callback(false, false);
+                }
+                callback(null, false);
+            });
+        }, () => {
+            throw new Error('should not get here');
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql([3,1]);
+            done();
+        }, 50);
     });
 
     it('rejectLimit', (done) => {
@@ -168,6 +264,26 @@ describe("reject", () => {
             expect(result).to.eql([4, 2]);
             done();
         });
+    });
+
+    it('rejectLimit canceled', (done) => {
+        var call_order = [];
+        async.filterLimit([1,1,2,2,3], 2, (x, callback) => {
+            call_order.push(x);
+            async.setImmediate(() => {
+                if (x === 2) {
+                    return callback(false, false);
+                }
+                callback(null, false);
+            });
+        }, () => {
+            throw new Error('should not get here');
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql([1,1,2,2]);
+            done();
+        }, 50);
     });
 
     it('filter fails', (done) => {

--- a/test/groupBy.js
+++ b/test/groupBy.js
@@ -45,7 +45,7 @@ describe('groupBy', function() {
                 }
                 next(null, val+1);
             }, () => {
-                throw new Error('final callback - should not get here');
+                throw new Error('should not get here');
             });
 
             setTimeout(() => {
@@ -234,7 +234,7 @@ describe('groupBy', function() {
                     next(null, val+1);
                 });
             }, () => {
-                throw new Error('final callback - should not get here');
+                throw new Error('should not get here');
             });
 
             setTimeout(() => {
@@ -368,7 +368,7 @@ describe('groupBy', function() {
                     next(null, val+1);
                 });
             }, () => {
-                throw new Error('final callback - should not get here');
+                throw new Error('should not get here');
             });
 
             setTimeout(() => {

--- a/test/groupBy.js
+++ b/test/groupBy.js
@@ -36,6 +36,24 @@ describe('groupBy', function() {
             });
         });
 
+        it('canceled', (done) => {
+            var callOrder = [];
+            async.groupBy([1, 3, 2], (val, next) => {
+                callOrder.push(val);
+                if (val === 3) {
+                    return next(false, val+1);
+                }
+                next(null, val+1);
+            }, () => {
+                throw new Error('final callback - should not get here');
+            });
+
+            setTimeout(() => {
+                expect(callOrder).to.eql([1, 3]);
+                done();
+            }, 25);
+        });
+
         it('original untouched', (done) => {
             var obj = {a: 'b', b: 'c', c: 'd'};
             async.groupBy(obj, (val, next) => {
@@ -205,6 +223,26 @@ describe('groupBy', function() {
             });
         });
 
+        it('canceled', (done) => {
+            var callOrder = [];
+            async.groupByLimit([1, 1, 2, 2, 3], 2, (val, next) => {
+                callOrder.push(val);
+                async.setImmediate(() => {
+                    if (val === 2) {
+                        return next(false, val+1);
+                    }
+                    next(null, val+1);
+                });
+            }, () => {
+                throw new Error('final callback - should not get here');
+            });
+
+            setTimeout(() => {
+                expect(callOrder).to.eql([1, 1, 2, 2]);
+                done();
+            }, 50);
+        });
+
         it('handles empty object', (done) => {
             async.groupByLimit({}, 2, (val, next) => {
                 assert(false, 'iteratee should not be called');
@@ -317,6 +355,26 @@ describe('groupBy', function() {
                 expect(result).to.eql({b: ['b']});
                 done();
             });
+        });
+
+        it('canceled', (done) => {
+            var callOrder = [];
+            async.groupBySeries([1, 2, 3], (val, next) => {
+                callOrder.push(val);
+                async.setImmediate(() => {
+                    if (val === 2) {
+                        return next(false, val+1);
+                    }
+                    next(null, val+1);
+                });
+            }, () => {
+                throw new Error('final callback - should not get here');
+            });
+
+            setTimeout(() => {
+                expect(callOrder).to.eql([1, 2]);
+                done();
+            }, 50);
         });
 
         it('handles arrays', (done) => {

--- a/test/map.js
+++ b/test/map.js
@@ -112,7 +112,7 @@ describe("map", () => {
             }
             callback(null, x * 2);
         }, () => {
-            throw new Error('final callback - should not get here');
+            throw new Error('should not get here');
         });
         setTimeout(() => {
             expect(call_order).to.eql([1, 2, 3]);
@@ -177,7 +177,7 @@ describe("map", () => {
                 callback(null, x * 2);
             });
         }, () => {
-            throw new Error('final callback - should not get here');
+            throw new Error('should not get here');
         });
         setTimeout(() => {
             expect(call_order).to.eql([1, 2]);
@@ -298,7 +298,7 @@ describe("map", () => {
                 callback(null, x * 2);
             });
         }, () => {
-            throw new Error('final callback - should not get here');
+            throw new Error('should not get here');
         });
         setTimeout(() => {
             expect(call_order).to.eql([1, 2, 3, 4]);

--- a/test/map.js
+++ b/test/map.js
@@ -103,6 +103,23 @@ describe("map", () => {
         setTimeout(done, 50);
     });
 
+    it('map canceled', (done) => {
+        var call_order = [];
+        async.map([1, 2, 3], (x, callback) => {
+            call_order.push(x);
+            if (x === 2) {
+                return callback(false, x * 2);
+            }
+            callback(null, x * 2);
+        }, () => {
+            throw new Error('final callback - should not get here');
+        });
+        setTimeout(() => {
+            expect(call_order).to.eql([1, 2, 3]);
+            done();
+        }, 25);
+    });
+
     it('map undefined array', (done) => {
         async.map(undefined, (x, callback) => {
             callback();
@@ -147,6 +164,25 @@ describe("map", () => {
             expect(err).to.equal('error');
         });
         setTimeout(done, 50);
+    });
+
+    it('mapSeries canceled', (done) => {
+        var call_order = [];
+        async.mapSeries([1, 2, 3], (x, callback) => {
+            call_order.push(x);
+            async.setImmediate(() => {
+                if (x === 2) {
+                    return callback(false, x * 2);
+                }
+                callback(null, x * 2);
+            });
+        }, () => {
+            throw new Error('final callback - should not get here');
+        });
+        setTimeout(() => {
+            expect(call_order).to.eql([1, 2]);
+            done();
+        }, 50);
     });
 
     it('mapSeries undefined array', (done) => {
@@ -249,6 +285,25 @@ describe("map", () => {
             expect(err).to.equal('error');
         });
         setTimeout(done, 25);
+    });
+
+    it('mapLimit canceled', (done) => {
+        var call_order = [];
+        async.mapLimit([1, 2, 3, 4, 5], 2, (x, callback) => {
+            call_order.push(x);
+            async.setImmediate(() => {
+                if (x === 3) {
+                    return callback(false, x * 2);
+                }
+                callback(null, x * 2);
+            });
+        }, () => {
+            throw new Error('final callback - should not get here');
+        });
+        setTimeout(() => {
+            expect(call_order).to.eql([1, 2, 3, 4]);
+            done();
+        }, 50);
     });
 
     it('mapLimit does not continue replenishing after error', (done) => {

--- a/test/mapValues.js
+++ b/test/mapValues.js
@@ -2,7 +2,7 @@ var async = require('../lib');
 var {expect} = require('chai');
 
 describe('mapValues', () => {
-    var obj = {a: 1, b: 2, c: 3};
+    var obj = {a: 1, b: 2, c: 3, d: 4};
 
     context('mapValuesLimit', () => {
         it('basics', (done) => {
@@ -10,7 +10,8 @@ describe('mapValues', () => {
             var concurrency = {
                 a: 2,
                 b: 2,
-                c: 1
+                c: 2,
+                d: 1
             };
             async.mapValuesLimit(obj, 2, (val, key, next) => {
                 running++;
@@ -22,7 +23,7 @@ describe('mapValues', () => {
             }, (err, result) => {
                 expect(running).to.equal(0);
                 expect(err).to.eql(null);
-                expect(result).to.eql({a: 'a1', b: 'b2', c: 'c3'});
+                expect(result).to.eql({a: 'a1', b: 'b2', c: 'c3', d: 'd4'});
                 done();
             });
         });
@@ -39,15 +40,36 @@ describe('mapValues', () => {
                 done();
             });
         });
+
+        it('canceled', (done) => {
+            var callOrder = [];
+            async.mapValuesLimit(obj, 2, (val, key, next) => {
+                callOrder.push(val, key);
+                async.setImmediate(() => {
+                    if (key === 'b') {
+                        return next(false);
+                    }
+                    next(null, val);
+                });
+            }, () => {
+                throw new Error('should not get here');
+            });
+
+            setTimeout(() => {
+                expect(callOrder).to.eql([1, 'a', 2, 'b', 3, 'c']);
+                done();
+            }, 50);
+        });
     });
 
     context('mapValues', () => {
         it('basics', (done) => {
             var running = 0;
             var concurrency = {
-                a: 3,
-                b: 2,
-                c: 1
+                a: 4,
+                b: 3,
+                c: 2,
+                d: 1
             };
             async.mapValues(obj, (val, key, next) => {
                 running++;
@@ -59,9 +81,27 @@ describe('mapValues', () => {
             }, (err, result) => {
                 expect(running).to.equal(0);
                 expect(err).to.eql(null);
-                expect(result).to.eql({a: 'a1', b: 'b2', c: 'c3'});
+                expect(result).to.eql({a: 'a1', b: 'b2', c: 'c3', d: 'd4'});
                 done();
             });
+        });
+
+        it('canceled', (done) => {
+            var callOrder = [];
+            async.mapValues(obj, (val, key, next) => {
+                callOrder.push(val, key);
+                if (key === 'b') {
+                    return next(false, val);
+                }
+                next(null, val);
+            }, () => {
+                throw new Error('should not get here');
+            });
+
+            setTimeout(() => {
+                expect(callOrder).to.eql([1, 'a', 2, 'b']);
+                done();
+            }, 25);
         });
     });
 
@@ -71,7 +111,8 @@ describe('mapValues', () => {
             var concurrency = {
                 a: 1,
                 b: 1,
-                c: 1
+                c: 1,
+                d: 1
             };
             async.mapValuesSeries(obj, (val, key, next) => {
                 running++;
@@ -83,9 +124,29 @@ describe('mapValues', () => {
             }, (err, result) => {
                 expect(running).to.equal(0);
                 expect(err).to.eql(null);
-                expect(result).to.eql({a: 'a1', b: 'b2', c: 'c3'});
+                expect(result).to.eql({a: 'a1', b: 'b2', c: 'c3', d: 'd4'});
                 done();
             });
+        });
+
+        it('canceled', (done) => {
+            var callOrder = [];
+            async.mapValuesSeries(obj, (val, key, next) => {
+                callOrder.push(val, key);
+                async.setImmediate(() => {
+                    if (key === 'b') {
+                        return next(false, val);
+                    }
+                    next(null, val);
+                });
+            }, () => {
+                throw new Error('should not get here');
+            });
+
+            setTimeout(() => {
+                expect(callOrder).to.eql([1, 'a', 2, 'b']);
+                done();
+            }, 50);
         });
     });
 });

--- a/test/parallel.js
+++ b/test/parallel.js
@@ -58,6 +58,27 @@ describe('parallel', () => {
         setTimeout(done, 100);
     });
 
+    it('parallel canceled', (done) => {
+        var call_order = [];
+        async.parallel([
+            function(callback) {
+                call_order.push('one');
+                callback(false);
+            },
+            function(callback){
+                call_order.push('two');
+                callback(null);
+            }
+        ], () => {
+            throw new Error('should not get here');
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql(['one', 'two']);
+            done();
+        }, 25);
+    });
+
     it('parallel no callback', (done) => {
         async.parallel([
             function(callback){callback();},

--- a/test/reduce.js
+++ b/test/reduce.js
@@ -35,6 +35,21 @@ describe('reduce', () => {
         setTimeout(done, 50);
     });
 
+    it('reduce canceled', (done) => {
+        var call_order = [];
+        async.reduce([1,2,3], 0, (a, x, callback) => {
+            call_order.push(x);
+            callback(x === 2 ? false : null, a + x)
+        }, () => {
+            throw new Error('should not get here');
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql([1, 2]);
+            done();
+        }, 25);
+    });
+
     it('inject alias', (done) => {
         expect(async.inject).to.equal(async.reduce);
         done();
@@ -57,6 +72,21 @@ describe('reduce', () => {
             expect(arr).to.eql([1,2,3]);
             done();
         });
+    });
+
+    it('reduceRight canceled', (done) => {
+        var call_order = [];
+        async.reduceRight([1,2,3], 0, (a, x, callback) => {
+            call_order.push(x);
+            callback(x === 2 ? false : null, a + x)
+        }, () => {
+            throw new Error('should not get here');
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql([3, 2]);
+            done();
+        }, 25);
     });
 
     it('foldr alias', (done) => {

--- a/test/retryable.js
+++ b/test/retryable.js
@@ -81,4 +81,20 @@ describe('retryable', () => {
             done();
         });
     });
+
+    it('should be cancelable', (done) => {
+        var calls = 0;
+        var retryableTask = async.retryable(3, (_, cb) => {
+            calls++;
+            cb(calls > 1 ? false : 'fail');
+        });
+        retryableTask('foo', () => {
+            throw new Error('should not get here');
+        })
+
+        setTimeout(() => {
+            expect(calls).to.equal(2);
+            done();
+        }, 25);
+    });
 });

--- a/test/seq.js
+++ b/test/seq.js
@@ -62,6 +62,31 @@ describe('seq', () => {
         });
     });
 
+    it('seq canceled', (done) => {
+        var call_order = [];
+
+        var add2 = function (n, cb) {
+            call_order.push('add2');
+            cb(null, n + 2);
+        };
+        var mul3 = function (n, cb) {
+            call_order.push('mul3');
+            cb(false, n * 3);
+        };
+        var add1 = function () {
+            throw new Error('add1 - should not get here');
+        };
+        var add2mul3add1 = async.seq(add2, mul3, add1);
+        add2mul3add1(3, () => {
+            throw new Error('final callback - should not get here');
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql(['add2', 'mul3']);
+            done();
+        }, 25);
+    });
+
     it('seq binding', (done) => {
         var testcontext = {name: 'foo'};
 

--- a/test/series.js
+++ b/test/series.js
@@ -92,6 +92,22 @@ describe('series', () => {
         setTimeout(done, 100);
     });
 
+    it('canceled', (done) => {
+        async.series([
+            function(callback) {
+                callback(false, 1);
+            },
+            function(callback) {
+                assert(false, 'second function - should not be called');
+                callback('error2', 2);
+            }
+        ], () => {
+            assert(false, 'final callback - should not be called');
+        });
+
+        setTimeout(done, 25);
+    });
+
     it('error with reflect', (done) => {
         async.series([
             async.reflect((callback) => {

--- a/test/series.js
+++ b/test/series.js
@@ -98,11 +98,11 @@ describe('series', () => {
                 callback(false, 1);
             },
             function(callback) {
-                assert(false, 'second function - should not be called');
+                assert(false, 'second function should not be called');
                 callback('error2', 2);
             }
         ], () => {
-            assert(false, 'final callback - should not be called');
+            assert(false, 'final callback should not be called');
         });
 
         setTimeout(done, 25);

--- a/test/some.js
+++ b/test/some.js
@@ -50,6 +50,24 @@ describe("some", () => {
         });
     });
 
+    it('some canceled', (done) => {
+        var call_order = [];
+        async.some([3,1,2], (x, callback) => {
+            call_order.push(x);
+            if (x === 1) {
+                return callback(false);
+            }
+            callback();
+        }, () => {
+            throw new Error('should not get here');
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql([3, 1, 2]);
+            done();
+        }, 25);
+    });
+
     it('some no callback', (done) => {
         var calls = [];
 
@@ -82,6 +100,46 @@ describe("some", () => {
             expect(result).to.equal(false);
             done();
         });
+    });
+
+    it('someLimit canceled', (done) => {
+        var call_order = [];
+        async.someLimit([1,1,2,2,3], 2, (x, callback) => {
+            call_order.push(x);
+            async.setImmediate(() => {
+                if (x === 2) {
+                    return callback(false);
+                }
+                callback();
+            });
+        }, () => {
+            throw new Error('should not get here');
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql([1, 1, 2, 2,]);
+            done();
+        }, 50);
+    });
+
+    it('someSeries canceled', (done) => {
+        var call_order = [];
+        async.someSeries([1, 2, 3], (x, callback) => {
+            call_order.push(x);
+            async.setImmediate(() => {
+                if (x === 2) {
+                    return callback(false);
+                }
+                callback();
+            });
+        }, () => {
+            throw new Error('should not get here');
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql([1, 2]);
+            done();
+        }, 50);
     });
 
     it('someLimit short-circuit', (done) => {

--- a/test/sortBy.js
+++ b/test/sortBy.js
@@ -33,4 +33,22 @@ describe('sortBy', () => {
             done();
         });
     });
+
+    it('sortBy canceled', (done) => {
+        var call_order = [];
+        async.sortBy([{a:1},{a:15},{a:6}], (x, callback) => {
+            call_order.push(x.a);
+            if (x.a === 15) {
+                return callback(false, x.a);
+            }
+            callback(null, x.a);
+        }, () => {
+            throw new Error('should not get here');
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql([1, 15, 6]);
+            done();
+        }, 25);
+    });
 });

--- a/test/times.js
+++ b/test/times.js
@@ -48,6 +48,24 @@ describe('times', () => {
         setTimeout(done, 50);
     });
 
+    it('times canceled', (done) => {
+        var call_order = [];
+        async.times(5, (n, callback) => {
+            call_order.push(n);
+            if (n === 2) {
+                return callback(false, n);
+            }
+            callback(null, n);
+        }, () => {
+            throw new Error('should not get here');
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql([0,1,2]);
+            done();
+        }, 25);
+    });
+
     it('timesSeries', (done) => {
         var call_order = [];
         async.timesSeries(5, (n, callback) => {
@@ -71,6 +89,26 @@ describe('times', () => {
         setTimeout(done, 50);
     });
 
+    it('timesSeries canceled', (done) => {
+        var call_order = [];
+        async.timesSeries(5, (n, callback) => {
+            call_order.push(n);
+            async.setImmediate(() => {
+                if (n === 2) {
+                    return callback(false, n);
+                }
+                callback(null, n);
+            })
+        }, () => {
+            throw new Error('should not get here');
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql([0,1,2]);
+            done();
+        }, 25);
+    });
+
     it('timesLimit', (done) => {
         var limit = 2;
         var running = 0;
@@ -86,5 +124,25 @@ describe('times', () => {
             expect(results).to.eql([0, 2, 4, 6, 8]);
             done();
         });
+    });
+
+    it('timesLimit canceled', (done) => {
+        var call_order = [];
+        async.timesLimit(5, 2, (n, callback) => {
+            call_order.push(n);
+            async.setImmediate(() => {
+                if (n === 2) {
+                    return callback(false, n);
+                }
+                callback(null, n);
+            })
+        }, () => {
+            throw new Error('should not get here');
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql([0,1,2,3]);
+            done();
+        }, 25);
     });
 });

--- a/test/transform.js
+++ b/test/transform.js
@@ -52,6 +52,22 @@ describe('transform', () => {
         });
     });
 
+    it('transform canceled', (done) => {
+        var call_order = [];
+        async.transform([1,2,3], (a, v, k, callback) => {
+            call_order.push(v);
+            a.push(v + 1);
+            callback(v === 2 ? false : null);
+        }, () => {
+            throw new Error('should not get here');
+        });
+
+        setTimeout(() => {
+            expect(call_order).to.eql([1, 2, 3]);
+            done();
+        }, 25);
+    });
+
     it('transform with two arguments', (done) => {
         try {
             async.transform([1, 2, 3], (a, v, k, callback) => {

--- a/test/tryEach.js
+++ b/test/tryEach.js
@@ -82,5 +82,23 @@ describe('tryEach', () => {
             done();
         });
     });
-});
+    it('canceled', (done) => {
+        var call_order = [];
+        async.tryEach([
+            function(callback) {
+                call_order.push('task1');
+                callback(false);
+            },
+            function() {
+                assert.fail('task2 - should not been called');
+            }
+        ], () => {
+            assert.fail('should not been called');
+        });
 
+        setTimeout(() => {
+            expect(call_order).to.eql(['task1']);
+            done();
+        }, 25);
+    });
+});

--- a/test/tryEach.js
+++ b/test/tryEach.js
@@ -90,7 +90,7 @@ describe('tryEach', () => {
                 callback(false);
             },
             function() {
-                assert.fail('task2 - should not been called');
+                assert.fail('task2 should not been called');
             }
         ], () => {
             assert.fail('should not been called');


### PR DESCRIPTION
This PR ensures that method pass the `err` onto `eachOfLimit`, so that they can be canceled properly. The one method I'm not quite sure about is `tryEach`. I'm assuming that since `retry` is cancelable, `tryEach` should be too?

Sorry if I went a little overboard with the tests, I ended up going down a rabbit hole :sweat_smile:. For the tests, I was trying to follow the coding style of the encompassing file, which is why some of the descriptions and styles vary. I figured it would be better to keep consistent logging and for future maintenance. 

