### PR TITLE
fix: priorityQueue drains while items still pending

### DIFF
--- a/lib/priorityQueue.js
+++ b/lib/priorityQueue.js
@@ -40,7 +40,7 @@ export default function(worker, concurrency) {
         if (!Array.isArray(data)) {
             data = [data];
         }
-        if (data.length === 0) {
+        if (data.length === 0 && q.idle()) {
             // call drain immediately if there are no tasks
             return setImmediate(() => q.drain());
         }

--- a/test/priorityQueue.js
+++ b/test/priorityQueue.js
@@ -269,6 +269,7 @@ describe('priorityQueue', () => {
             ]);
             expect(q.concurrency).to.equal(1);
             expect(q.length()).to.equal(0);
+            expect(q.running()).to.equal(0);
             done();
         };
         

--- a/test/priorityQueue.js
+++ b/test/priorityQueue.js
@@ -272,7 +272,7 @@ describe('priorityQueue', () => {
             done();
         };
         
-        q.push([], 1, (err, arg) => {});
+        q.push([], 1, () => {});
     });
 });
 


### PR DESCRIPTION
Priority queue should check if the underlying queue is idle before draining.

Currently the priorityQueue drains if an empty array of tasks is pushed even if other tasks are processing.