### PR TITLE
Remove --save option as it isn't required anymore

### DIFF
--- a/intro.md
+++ b/intro.md
@@ -9,7 +9,7 @@
 
 Async is a utility module which provides straight-forward, powerful functions
 for working with asynchronous JavaScript. Although originally designed for
-use with [Node.js](https://nodejs.org/) and installable via `npm install --save async`,
+use with [Node.js](https://nodejs.org/) and installable via `npm install async`,
 it can also be used directly in the browser.
 
 Async is also installable via:
@@ -218,7 +218,7 @@ The source is available for download from
 Alternatively, you can install using npm:
 
 ```bash
-$ npm install --save async
+$ npm install async
 ```
 
 As well as using Bower:
@@ -267,7 +267,7 @@ included in the `/dist` folder. Async can also be found on the [jsDelivr CDN](ht
 We also provide Async as a collection of ES2015 modules, in an alternative `async-es` package on npm.
 
 ```bash
-$ npm install --save async-es
+$ npm install async-es
 ```
 
 ```js


### PR DESCRIPTION
"As of npm 5.0.0, installed modules are added as a dependency by default, so the --save option is no longer needed. The other save options still exist and are listed in the documentation for npm install."

https://stackoverflow.com/a/19578808/142358