### PR TITLE
Check for name or message of Error before wrap in new Error

### DIFF
--- a/docs/v2/asyncify.js.html
+++ b/docs/v2/asyncify.js.html
@@ -63,15 +63,15 @@
 
 <div id="main">
     <div id="main-container" data-spy="scroll" data-target="#toc" data-offset="50">
-        
+
         <h1 class="page-title">asyncify.js</h1>
-        
-
-        
 
 
 
-    
+
+
+
+
     <section>
         <article>
             <pre class="prettyprint source linenums"><code>import isObject from &apos;lodash/isObject&apos;;
@@ -147,7 +147,7 @@ export default function asyncify(func) {
             result.then(function(value) {
                 invokeCallback(callback, null, value);
             }, function(err) {
-                invokeCallback(callback, err.message ? err : new Error(err));
+                invokeCallback(callback, (err.name || err.message) ? err : new Error(err));
             });
         } else {
             callback(null, result);

--- a/lib/asyncify.js
+++ b/lib/asyncify.js
@@ -87,7 +87,7 @@ function handlePromise(promise, callback) {
     return promise.then(value => {
         invokeCallback(callback, null, value);
     }, err => {
-        invokeCallback(callback, err && err.message ? err : new Error(err));
+        invokeCallback(callback, err && (err.name || err.message) ? err : new Error(err));
     });
 }
 

--- a/test/asyncify.js
+++ b/test/asyncify.js
@@ -45,6 +45,22 @@ describe('asyncify', () => {
         });
     });
 
+    it('catch custom errors extending Error class', (done) => {
+        class CustomError extends Error {
+            get name() {
+                return 'CustomError';
+            }
+        }
+        async.asyncify(() => {
+            const err = new CustomError();
+            throw err;
+        })((err) => {
+            assert(err);
+            expect(err.name).to.equal("CustomError");
+            done();
+        });
+    });
+
     it('dont catch errors in the callback', (done) => {
         try {
             async.asyncify(() => {})((err) => {


### PR DESCRIPTION
Relying on `err.message` is not great, because in some cases it might be undefined. That makes handling of errors really hard.