### PR TITLE
test to prove bug with await expectation on queue.drain

### DIFF
--- a/lib/internal/queue.js
+++ b/lib/internal/queue.js
@@ -132,16 +132,17 @@ export default function queue(worker, concurrency, payload) {
 
     const eventMethod = (name) => (handler) => {
         if (!handler) {
-            return new Promise((resolve, reject) => {
+            const p = new Promise((resolve, reject) => {
                 once(name, (err, data) => {
                     if (err) return reject(err)
                     resolve(data)
                 })
             })
+            _maybeDrain([]);
+            return p;
         }
         off(name)
         on(name, handler)
-
     }
 
     var isProcessing = false;

--- a/test/queue.js
+++ b/test/queue.js
@@ -125,6 +125,13 @@ describe('queue', function(){
         done();
     });
 
+    it('correctly awaitable', async () => {
+        var q = async.queue((t, cb) => cb(null, t));
+        q.push(1, () => {});
+        await q.drain();
+        await q.drain();
+    });
+
     it('error propagation', (done) => {
         var results = [];
 

--- a/test/queue.js
+++ b/test/queue.js
@@ -128,8 +128,21 @@ describe('queue', function(){
     it('correctly awaitable', async () => {
         var q = async.queue((t, cb) => cb(null, t));
         q.push(1, () => {});
-        await q.drain();
-        await q.drain();
+        // double await
+        const p = await q.drain();
+        await p;
+
+        // await on empty queue
+        const p2 = q.drain();
+        await p2;
+
+        // await on queue refilled
+        q.push(1, () => {});
+        const p3 = q.drain();
+        await p3;
+        expect(p).to.not.eql(p2);
+        expect(p).to.not.eql(p3);
+        expect(p2).to.not.eql(p3);
     });
 
     it('error propagation', (done) => {


### PR DESCRIPTION
I was expecting the drain function to always return the same promise. But since a promise cannot resolve more then once it would break the expectation of how you use the queue. Especially in the case where the queue would start and stop. For instance you add more items to the queue after it has drained once. 

@aearly Pinging you since you were the original implementor of the awaitable feature