### PR TITLE
fix: handle ES2017 Async Functions in `async.apply()`

### DIFF
--- a/lib/apply.js
+++ b/lib/apply.js
@@ -1,4 +1,5 @@
 import { isAsync } from './internal/wrapAsync';
+import asyncify from './asyncify';
 
 /**
  * Creates a continuation function with some arguments already applied.
@@ -46,7 +47,6 @@ import { isAsync } from './internal/wrapAsync';
  * three
  */
 export default function(fn, ...args) {
-    return isAsync(fn)
-        ? async (...callArgs) => fn(...args,...callArgs)
-        : (...callArgs) => fn(...args,...callArgs);
+    const appliedFn = (...callArgs) => fn(...args,...callArgs);
+    return isAsync(fn) ? asyncify(appliedFn) : appliedFn;
 }

--- a/lib/apply.js
+++ b/lib/apply.js
@@ -1,3 +1,5 @@
+import { isAsync } from './internal/wrapAsync';
+
 /**
  * Creates a continuation function with some arguments already applied.
  *
@@ -44,5 +46,7 @@
  * three
  */
 export default function(fn, ...args) {
-    return (...callArgs) => fn(...args,...callArgs);
+    return isAsync(fn)
+        ? async (...callArgs) => fn(...args,...callArgs)
+        : (...callArgs) => fn(...args,...callArgs);
 }

--- a/test/es2017/asyncFunctions.js
+++ b/test/es2017/asyncFunctions.js
@@ -271,6 +271,11 @@ module.exports = function () {
      * Control Flow
      */
 
+    it('should handle async functions in apply', () => {
+        const result = async.apply(asyncIdentity, input);
+        expect(result[Symbol.toStringTag]).to.eql('AsyncFunction');
+    });
+
     it('should handle async functions in applyEach', (done) => {
         async.applyEach([asyncIdentity, asyncIdentity], input)((err, result) => {
             expect(result).to.eql([input, input]);

--- a/test/es2017/asyncFunctions.js
+++ b/test/es2017/asyncFunctions.js
@@ -271,9 +271,11 @@ module.exports = function () {
      * Control Flow
      */
 
-    it('should handle async functions in apply', () => {
-        const result = async.apply(asyncIdentity, input);
-        expect(result[Symbol.toStringTag]).to.eql('AsyncFunction');
+    it('should handle async functions in apply', (done) => {
+        async.apply(asyncIdentity, input)((err, result) => {
+            expect(result).to.eql(input);
+            done(err);
+        });
     });
 
     it('should handle async functions in applyEach', (done) => {


### PR DESCRIPTION
Previously, `async.apply()` always returns a regular function, even if an async function was passed in. This meant, for example, that `async.apply()` would not be able to be used in other methods without
wrapping in `async.asyncify()`.

This fix checks what type of function was passed in, and returns the same type.