### PR TITLE
docs: Fix simple typo, whoses -> whose

### DIFF
--- a/dist/async.js
+++ b/dist/async.js
@@ -2590,7 +2590,7 @@
      * The iteratee should complete with a `key` to group the value under.
      * Invoked with (value, callback).
      * @param {Function} [callback] - A callback which is called when all `iteratee`
-     * functions have finished, or an error occurs. Result is an `Object` whoses
+     * functions have finished, or an error occurs. Result is an `Object` whose
      * properties are arrays of values which returned the corresponding key.
      * @returns {Promise} a promise, if no callback is passed
      */
@@ -2647,7 +2647,7 @@
      * The iteratee should complete with a `key` to group the value under.
      * Invoked with (value, callback).
      * @param {Function} [callback] - A callback which is called when all `iteratee`
-     * functions have finished, or an error occurs. Result is an `Object` whoses
+     * functions have finished, or an error occurs. Result is an `Object` whose
      * properties are arrays of values which returned the corresponding key.
      * @returns {Promise} a promise, if no callback is passed
      * @example
@@ -2681,7 +2681,7 @@
      * The iteratee should complete with a `key` to group the value under.
      * Invoked with (value, callback).
      * @param {Function} [callback] - A callback which is called when all `iteratee`
-     * functions have finished, or an error occurs. Result is an `Object` whoses
+     * functions have finished, or an error occurs. Result is an `Object` whose
      * properties are arrays of values which returned the corresponding key.
      * @returns {Promise} a promise, if no callback is passed
      */

--- a/docs/v2/scripts/async.js
+++ b/docs/v2/scripts/async.js
@@ -3532,7 +3532,7 @@ function forever(fn, errback) {
  * The iteratee should complete with a `key` to group the value under.
  * Invoked with (value, callback).
  * @param {Function} [callback] - A callback which is called when all `iteratee`
- * functions have finished, or an error occurs. Result is an `Object` whoses
+ * functions have finished, or an error occurs. Result is an `Object` whose
  * properties are arrays of values which returned the corresponding key.
  */
 var groupByLimit = function(coll, limit, iteratee, callback) {
@@ -3587,7 +3587,7 @@ var groupByLimit = function(coll, limit, iteratee, callback) {
  * The iteratee should complete with a `key` to group the value under.
  * Invoked with (value, callback).
  * @param {Function} [callback] - A callback which is called when all `iteratee`
- * functions have finished, or an error occurs. Result is an `Object` whoses
+ * functions have finished, or an error occurs. Result is an `Object` whose
  * properties are arrays of values which returned the corresponding key.
  * @example
  *
@@ -3619,7 +3619,7 @@ var groupBy = doLimit(groupByLimit, Infinity);
  * The iteratee should complete with a `key` to group the value under.
  * Invoked with (value, callback).
  * @param {Function} [callback] - A callback which is called when all `iteratee`
- * functions have finished, or an error occurs. Result is an `Object` whoses
+ * functions have finished, or an error occurs. Result is an `Object` whose
  * properties are arrays of values which returned the corresponding key.
  */
 var groupBySeries = doLimit(groupByLimit, 1);

--- a/docs/v3/scripts/async.js
+++ b/docs/v3/scripts/async.js
@@ -2590,7 +2590,7 @@
      * The iteratee should complete with a `key` to group the value under.
      * Invoked with (value, callback).
      * @param {Function} [callback] - A callback which is called when all `iteratee`
-     * functions have finished, or an error occurs. Result is an `Object` whoses
+     * functions have finished, or an error occurs. Result is an `Object` whose
      * properties are arrays of values which returned the corresponding key.
      * @returns {Promise} a promise, if no callback is passed
      */
@@ -2647,7 +2647,7 @@
      * The iteratee should complete with a `key` to group the value under.
      * Invoked with (value, callback).
      * @param {Function} [callback] - A callback which is called when all `iteratee`
-     * functions have finished, or an error occurs. Result is an `Object` whoses
+     * functions have finished, or an error occurs. Result is an `Object` whose
      * properties are arrays of values which returned the corresponding key.
      * @returns {Promise} a promise, if no callback is passed
      * @example
@@ -2681,7 +2681,7 @@
      * The iteratee should complete with a `key` to group the value under.
      * Invoked with (value, callback).
      * @param {Function} [callback] - A callback which is called when all `iteratee`
-     * functions have finished, or an error occurs. Result is an `Object` whoses
+     * functions have finished, or an error occurs. Result is an `Object` whose
      * properties are arrays of values which returned the corresponding key.
      * @returns {Promise} a promise, if no callback is passed
      */

--- a/lib/groupBySeries.js
+++ b/lib/groupBySeries.js
@@ -15,7 +15,7 @@ import groupByLimit from './groupByLimit';
  * The iteratee should complete with a `key` to group the value under.
  * Invoked with (value, callback).
  * @param {Function} [callback] - A callback which is called when all `iteratee`
- * functions have finished, or an error occurs. Result is an `Object` whoses
+ * functions have finished, or an error occurs. Result is an `Object` whose
  * properties are arrays of values which returned the corresponding key.
  * @returns {Promise} a promise, if no callback is passed
  */


### PR DESCRIPTION
There is a small typo in dist/async.js, docs/v2/scripts/async.js, docs/v3/scripts/async.js, lib/groupBySeries.js.

Should read `whose` rather than `whoses`.

