### PR TITLE
use queueMicrotask instead of setTimeout in browsers to avoid browser throttling

### DIFF
--- a/lib/internal/setImmediate.js
+++ b/lib/internal/setImmediate.js
@@ -1,6 +1,7 @@
 'use strict';
 /* istanbul ignore file */
 
+export var hasQueueMicrotask = typeof queueMicrotask === 'function' && queueMicrotask;
 export var hasSetImmediate = typeof setImmediate === 'function' && setImmediate;
 export var hasNextTick = typeof process === 'object' && typeof process.nextTick === 'function';
 
@@ -14,7 +15,9 @@ export function wrap(defer) {
 
 var _defer;
 
-if (hasSetImmediate) {
+if (hasQueueMicrotask) {
+    _defer = queueMicrotask;
+} else if (hasSetImmediate) {
     _defer = setImmediate;
 } else if (hasNextTick) {
     _defer = process.nextTick;

--- a/test/cargoQueue.js
+++ b/test/cargoQueue.js
@@ -76,12 +76,12 @@ describe('cargoQueue', () => {
         var call_order = [];
         var c = async.cargoQueue(worker.bind({ call_order }), 2, 2);
         c.push(1);
-        setImmediate(() => {
+        async.setImmediate(() => {
             c.push(2);
-            setImmediate(() => {
+            async.setImmediate(() => {
                 c.push(3);
                 c.push(4);
-                setImmediate(() => {
+                async.setImmediate(() => {
                     c.push(5);
                     c.drain(() => {
                         expect(call_order).to.eql([


### PR DESCRIPTION
Since `setTimeout` get throttled by browsers and `setImmediate` doesn't actually exist in any browsers, we should use `queueMicrotask` which works very similarly to the intention of `setImmediate`.

I have an app that uses stanza.io which relies on async's `priorityQueue`. It was found that `priorityQueue` is getting throttled because of its use of `setTimeout(fn, 0)`. Most browsers support `queueMicrotask`, but for those who don't, we will fallback.