### PR TITLE
Fix(docs): use plural `callbacks` word in `lib/map.js`

### DIFF
--- a/lib/map.js
+++ b/lib/map.js
@@ -5,7 +5,7 @@ import awaitify from './internal/awaitify'
 /**
  * Produces a new collection of values by mapping each value in `coll` through
  * the `iteratee` function. The `iteratee` is called with an item from `coll`
- * and a callback for when it has finished processing. Each of these callback
+ * and a callback for when it has finished processing. Each of these callbacks
  * takes 2 arguments: an `error`, and the transformed item from `coll`. If
  * `iteratee` passes an error to its callback, the main `callback` (for the
  * `map` function) is immediately called with the error.


### PR DESCRIPTION
This is just a grammar issue.