### PR TITLE
fix: address edge case in comment stripping

### DIFF
--- a/lib/autoInject.js
+++ b/lib/autoInject.js
@@ -6,11 +6,37 @@ var FN_ARGS = /^(?:async\s+)?(?:function)?\s*\w*\s*\(\s*([^)]+)\s*\)(?:\s*{)/;
 var ARROW_FN_ARGS = /^(?:async\s+)?\(?\s*([^)=]+)\s*\)?(?:\s*=>)/;
 var FN_ARG_SPLIT = /,/;
 var FN_ARG = /(=.+)?(\s*)$/;
-var STRIP_COMMENTS = /(\/\*(?:[^/]|\/(?!\*))*\*\/)|\/\/.*$/mg;
+
+function stripComments(string) {
+    let stripped = '';
+    let index = 0;
+    let endBlockComment = string.indexOf('*/');
+    while (index < string.length) {
+        if (string[index] === '/' && string[index+1] === '/') {
+            // inline comment
+            let endIndex = string.indexOf('\n', index);
+            index = (endIndex === -1) ? string.length : endIndex;
+        } else if ((endBlockComment !== -1) && (string[index] === '/') && (string[index+1] === '*')) {
+            // block comment
+            let endIndex = string.indexOf('*/', index);
+            if (endIndex !== -1) {
+                index = endIndex + 2;
+                endBlockComment = string.indexOf('*/', index);
+            } else {
+                stripped += string[index];
+                index++;
+            }
+        } else {
+            stripped += string[index];
+            index++;
+        }
+    }
+    return stripped;
+}
 
 function parseParams(func) {
-    const src = func.toString().replace(STRIP_COMMENTS, '');
-    let match = src.match(FN_ARGS)
+    const src = stripComments(func.toString());
+    let match = src.match(FN_ARGS);
     if (!match) {
         match = src.match(ARROW_FN_ARGS);
     }

--- a/test/autoInject.js
+++ b/test/autoInject.js
@@ -243,13 +243,17 @@ describe('autoInject', () => {
                 ,callback) {
                 callback(null, true);
             },
-            task3: function task3(callback) {
+            task3: function task3(task4 /* /* )
+                */, callback) {
                 callback(null, true);
-            }
+            },
+            task4: function task4(callback) {
+                callback(null, true);
+            },
         },
         (err, result) => {
             expect(err).to.eql(null);
-            expect(result).to.deep.eql({task1: true, task2: true, task3: true});
+            expect(result).to.deep.eql({task1: true, task2: true, task3: true, task4: true});
             done();
         });
     });


### PR DESCRIPTION
Unforunately, cdfb4917e6028c8f966276d6e792018c7fd2ae3c introduced issues
with certain edge cases for comments. Fixing the edge case in the
regular expression is likely to reintroduce the issue that commit was
addressing. This change replaces the regular expression entirely with
a function that iterates through the string instead of regular
expressions.