### PR TITLE
docs: add missing return definitions for awaitable functions [fixes #1777]

### DIFF
--- a/lib/detect.js
+++ b/lib/detect.js
@@ -27,7 +27,7 @@ import awaitify from './internal/awaitify.js'
  * Result will be the first item in the array that passes the truth test
  * (iteratee) or the value `undefined` if none passed. Invoked with
  * (err, result).
- * @returns A Promise, if no callback is passed
+ * @returns {Promise} a promise, if a callback is omitted
  * @example
  *
  * // dir1 is a directory that contains file1.txt, file2.txt

--- a/lib/detectLimit.js
+++ b/lib/detectLimit.js
@@ -23,7 +23,7 @@ import awaitify from './internal/awaitify.js'
  * Result will be the first item in the array that passes the truth test
  * (iteratee) or the value `undefined` if none passed. Invoked with
  * (err, result).
- * @returns a Promise if no callback is passed
+ * @returns {Promise} a promise, if a callback is omitted
  */
 function detectLimit(coll, limit, iteratee, callback) {
     return createTester(bool => bool, (res, item) => item)(eachOfLimit(limit), coll, iteratee, callback)

--- a/lib/detectSeries.js
+++ b/lib/detectSeries.js
@@ -21,7 +21,7 @@ import awaitify from './internal/awaitify.js'
  * Result will be the first item in the array that passes the truth test
  * (iteratee) or the value `undefined` if none passed. Invoked with
  * (err, result).
- * @returns a Promise if no callback is passed
+ * @returns {Promise} a promise, if a callback is omitted
  */
 function detectSeries(coll, iteratee, callback) {
     return createTester(bool => bool, (res, item) => item)(eachOfLimit(1), coll, iteratee, callback)

--- a/lib/race.js
+++ b/lib/race.js
@@ -18,7 +18,7 @@ import awaitify from './internal/awaitify.js'
  * @param {Function} callback - A callback to run once any of the functions have
  * completed. This function gets an error or result from the first function that
  * completed. Invoked with (err, result).
- * @returns undefined
+ * @returns {Promise} a promise, if a callback is omitted
  * @example
  *
  * async.race([

--- a/lib/waterfall.js
+++ b/lib/waterfall.js
@@ -21,7 +21,7 @@ import awaitify from './internal/awaitify.js'
  * @param {Function} [callback] - An optional callback to run once all the
  * functions have completed. This will be passed the results of the last task's
  * callback. Invoked with (err, [results]).
- * @returns undefined
+ * @returns {Promise} a promise, if a callback is omitted
  * @example
  *
  * async.waterfall([


### PR DESCRIPTION
Hey! It's been a while since I contributed to the repo, so I thought I would start with a couple of quick doc updates.

This PR adds the missing return definitions for `race` and `waterfall` and updates the `detect*` docs to match the style of all the other functions.