### PR TITLE
update priorityQueue functionality to match queue [fixes #1725]

### DIFF
--- a/lib/internal/queue.js
+++ b/lib/internal/queue.js
@@ -60,12 +60,11 @@ export default function queue(worker, concurrency, payload) {
             res(args)
         }
 
-        var item = {
+        var item = q._createTaskItem(
             data,
-            callback: rejectOnError ?
-                promiseCallback :
+            rejectOnError ? promiseCallback :
                 (callback || promiseCallback)
-        };
+        );
 
         if (insertAtFront) {
             q._tasks.unshift(item);
@@ -147,6 +146,12 @@ export default function queue(worker, concurrency, payload) {
     var isProcessing = false;
     var q = {
         _tasks: new DLL(),
+        _createTaskItem (data, callback) {
+            return {
+                data,
+                callback
+            };
+        },
         *[Symbol.iterator] () {
             yield* q._tasks[Symbol.iterator]()
         },

--- a/lib/priorityQueue.js
+++ b/lib/priorityQueue.js
@@ -1,4 +1,3 @@
-import setImmediate from './setImmediate.js'
 import queue from './queue.js'
 import Heap from './internal/Heap.js'
 
@@ -19,54 +18,51 @@ import Heap from './internal/Heap.js'
  * @param {number} concurrency - An `integer` for determining how many `worker`
  * functions should be run in parallel.  If omitted, the concurrency defaults to
  * `1`.  If the concurrency is `0`, an error is thrown.
- * @returns {module:ControlFlow.QueueObject} A priorityQueue object to manage the tasks. There are two
+ * @returns {module:ControlFlow.QueueObject} A priorityQueue object to manage the tasks. There are three
  * differences between `queue` and `priorityQueue` objects:
  * * `push(task, priority, [callback])` - `priority` should be a number. If an
  *   array of `tasks` is given, all tasks will be assigned the same priority.
- * * The `unshift` method was removed.
+ * * `pushAsync(task, priority, [callback])` - the same as `priorityQueue.push`,
+ *   except this returns a promise that rejects if an error occurs.
+ * * The `unshift` and `unshiftAsync` methods were removed.
  */
 export default function(worker, concurrency) {
     // Start with a normal queue
     var q = queue(worker, concurrency);
-    var processingScheduled = false;
+
+    var {
+        push,
+        pushAsync
+    } = q;
 
     q._tasks = new Heap();
-
-    // Override push to accept second parameter representing priority
-    q.push = function(data, priority = 0, callback = () => {}) {
-        if (typeof callback !== 'function') {
-            throw new Error('task callback must be a function');
-        }
-        q.started = true;
-        if (!Array.isArray(data)) {
-            data = [data];
-        }
-        if (data.length === 0 && q.idle()) {
-            // call drain immediately if there are no tasks
-            return setImmediate(() => q.drain());
-        }
-
-        for (var i = 0, l = data.length; i < l; i++) {
-            var item = {
-                data: data[i],
-                priority,
-                callback
-            };
-
-            q._tasks.push(item);
-        }
-
-        if (!processingScheduled) {
-            processingScheduled = true;
-            setImmediate(() => {
-                processingScheduled = false;
-                q.process();
-            });
-        }
+    q._createTaskItem = ({data, priority}, callback) => {
+        return {
+            data,
+            priority,
+            callback
+        };
     };
 
-    // Remove unshift function
+    function createDataItems(tasks, priority) {
+        if (!Array.isArray(tasks)) {
+            return {data: tasks, priority};
+        }
+        return tasks.map(data => { return {data, priority}; });
+    }
+
+    // Override push to accept second parameter representing priority
+    q.push = function(data, priority = 0, callback) {
+        return push(createDataItems(data, priority), callback);
+    };
+
+    q.pushAsync = function(data, priority = 0, callback) {
+        return pushAsync(createDataItems(data, priority), callback);
+    };
+
+    // Remove unshift functions
     delete q.unshift;
+    delete q.unshiftAsync;
 
     return q;
 }

--- a/test/queue.js
+++ b/test/queue.js
@@ -170,7 +170,6 @@ describe('queue', function(){
         })
         q.pushAsync([3, 4]).map(p => p.then(() => calls.push('arr')))
         q.drain(() => setTimeout(() => {
-            console.log('drain')
             expect(calls).to.eql([1, 2, 'arr', 'arr'])
             done()
         }))
@@ -190,7 +189,6 @@ describe('queue', function(){
         })
         q.unshiftAsync([3, 4]).map(p => p.then(() => calls.push('arr')))
         q.drain(() => setTimeout(() => {
-            console.log('drain')
             expect(calls).to.eql(['arr', 'arr', 2, 1])
             done()
         }))


### PR DESCRIPTION
This PR updates the `priorityQueue` behaviour to match the `queue` implementation:
* better supports promises in `priorityQueue` (see #1725).
* supports `pushAsync` and removes `unshiftAsync`.
* fixes a bug where `drain` wasn't being called when an empty task was pushed.
* eliminates duplicate code by keeping all of the `queue` logic in `queue`. The one issue with this is it now iterates over the `tasks` twice, once in `priorityQueue` and once in `queue`. Let me know if there's a better way you can think of.

I also added a few tests from `queue` to `priorityQueue` to make sure the functionality matches. 