### PR TITLE
Fix prototype pollution vulnerability

### DIFF
--- a/lib/internal/iterator.js
+++ b/lib/internal/iterator.js
@@ -27,6 +27,9 @@ function createObjectIterator(obj) {
     var len = okeys.length;
     return function next() {
         var key = okeys[++i];
+        if (key === '__proto__') {
+            return next();
+        }
         return i < len ? {value: obj[key], key: key} : null;
     };
 }

--- a/mocha_test/mapValues.js
+++ b/mocha_test/mapValues.js
@@ -39,6 +39,17 @@ describe('mapValues', function () {
                 done();
             });
         });
+
+        it('prototype pollution', (done) => {
+            var input = JSON.parse('{"a": 1, "b": 2, "__proto__": { "exploit": true }}');
+
+            async.mapValues(input, (val, key, next) => {
+                next(null, val)
+            }, (err, result) => {
+                expect(result.exploit).to.equal(undefined)
+                done(err);
+            })
+        })
     });
 
     context('mapValues', function () {


### PR DESCRIPTION
(cherry picked from commit e1ecdbf79264f9ab488c7799f4c76996d5dca66d)

Conflicts:
  lib/internal/iterator.js
  test/mapValues.js

NOTE(mriedem): The conflicts are due to:

- e4751178540a3c6e64598b93977481ec599704d2 for iterator.js;
  resolution was trivial
- bd86f42a7d71552d9a502b50235ffc090a1b4a98 for mapValues.js;
  resolution was just copying the test change into the old
  test file before it was moved

This is a 2.x series backport for
https://nvd.nist.gov/vuln/detail/CVE-2021-43138.