### PR TITLE
Update queue.js

### DIFF
--- a/lib/internal/queue.js
+++ b/lib/internal/queue.js
@@ -123,7 +123,7 @@ export default function queue(worker, concurrency, payload) {
     function _maybeDrain(data) {
         if (data.length === 0 && q.idle()) {
             // call drain immediately if there are no tasks
-            setImmediate(() => trigger('drain'));
+            setImmediate(() => void q.idle() && trigger('drain'));
             return true
         }
         return false


### PR DESCRIPTION
This fixes an bug: Drain function got called even when some tasks still ongoing at the queue. Fix proposal is due to https://github.com/caolan/async/issues/1729 (@Domiii) Tested by me locally. Works great.