### PR TITLE
fix: eliminate circular dependency

### DIFF
--- a/docs/v2/autoInject.js.html
+++ b/docs/v2/autoInject.js.html
@@ -80,7 +80,7 @@ import arrayMap from &apos;lodash/_arrayMap&apos;;
 import isArray from &apos;lodash/isArray&apos;;
 import trim from &apos;lodash/trim&apos;;
 import wrapAsync from &apos;./internal/wrapAsync&apos;;
-import { isAsync } from &apos;./internal/wrapAsync&apos;;
+import { isAsync } from &apos;./internal/isAsync&apos;;
 
 var FN_ARGS = /^(?:async\s+)?(function)?\s*[^\(]*\(\s*([^\)]*)\)/m;
 var FN_ARG_SPLIT = /,/;

--- a/docs/v2/ensureAsync.js.html
+++ b/docs/v2/ensureAsync.js.html
@@ -76,7 +76,7 @@
         <article>
             <pre class="prettyprint source linenums"><code>import setImmediate from &apos;./internal/setImmediate&apos;;
 import initialParams from &apos;./internal/initialParams&apos;;
-import { isAsync } from &apos;./internal/wrapAsync&apos;;
+import { isAsync } from &apos;./internal/isAsync&apos;;
 
 /**
  * Wrap an async function and ensure it calls its callback on a later tick of

--- a/docs/v3/asyncify.js.html
+++ b/docs/v3/asyncify.js.html
@@ -77,7 +77,7 @@
         <article>
             <pre class="prettyprint source linenums"><code>import initialParams from &apos;./internal/initialParams.js&apos;
 import setImmediate from &apos;./internal/setImmediate.js&apos;
-import { isAsync } from &apos;./internal/wrapAsync.js&apos;
+import { isAsync } from &apos;./internal/isAsync.js&apos;
 
 /**
  * Take a sync function and make it async, passing its return value to a

--- a/docs/v3/autoInject.js.html
+++ b/docs/v3/autoInject.js.html
@@ -77,7 +77,7 @@
         <article>
             <pre class="prettyprint source linenums"><code>import auto from &apos;./auto.js&apos;
 import wrapAsync from &apos;./internal/wrapAsync.js&apos;
-import { isAsync } from &apos;./internal/wrapAsync.js&apos;
+import { isAsync } from &apos;./internal/isAsync.js&apos;
 
 var FN_ARGS = /^(?:async\s+)?(?:function)?\s*\w*\s*\(\s*([^)]+)\s*\)(?:\s*{)/;
 var ARROW_FN_ARGS = /^(?:async\s+)?\(?\s*([^)=]+)\s*\)?(?:\s*=&gt;)/;

--- a/docs/v3/ensureAsync.js.html
+++ b/docs/v3/ensureAsync.js.html
@@ -76,7 +76,7 @@
     <section>
         <article>
             <pre class="prettyprint source linenums"><code>import setImmediate from &apos;./internal/setImmediate.js&apos;
-import { isAsync } from &apos;./internal/wrapAsync.js&apos;
+import { isAsync } from &apos;./internal/isAsync.js&apos;
 
 /**
  * Wrap an async function and ensure it calls its callback on a later tick of

--- a/docs/v3/retryable.js.html
+++ b/docs/v3/retryable.js.html
@@ -77,7 +77,8 @@
         <article>
             <pre class="prettyprint source linenums"><code>import retry from &apos;./retry.js&apos;
 import initialParams from &apos;./internal/initialParams.js&apos;
-import {default as wrapAsync, isAsync} from &apos;./internal/wrapAsync.js&apos;
+import wrapAsync from &apos;./internal/wrapAsync.js&apos;
+import { isAsync } from &apos;./internal/isAsync.js&apos;
 import { promiseCallback, PROMISE_SYMBOL } from &apos;./internal/promiseCallback.js&apos;
 
 /**

--- a/lib/asyncify.js
+++ b/lib/asyncify.js
@@ -1,6 +1,6 @@
 import initialParams from './internal/initialParams.js'
 import setImmediate from './internal/setImmediate.js'
-import { isAsync } from './internal/wrapAsync.js'
+import { isAsync } from './internal/isAsync.js'
 
 /**
  * Take a sync function and make it async, passing its return value to a

--- a/lib/autoInject.js
+++ b/lib/autoInject.js
@@ -1,6 +1,6 @@
 import auto from './auto.js'
 import wrapAsync from './internal/wrapAsync.js'
-import { isAsync } from './internal/wrapAsync.js'
+import { isAsync } from './internal/isAsync.js'
 
 var FN_ARGS = /^(?:async\s+)?(?:function)?\s*\w*\s*\(\s*([^)]+)\s*\)(?:\s*{)/;
 var ARROW_FN_ARGS = /^(?:async\s+)?\(?\s*([^)=]+)\s*\)?(?:\s*=>)/;

--- a/lib/ensureAsync.js
+++ b/lib/ensureAsync.js
@@ -1,5 +1,5 @@
 import setImmediate from './internal/setImmediate.js'
-import { isAsync } from './internal/wrapAsync.js'
+import { isAsync } from './internal/isAsync.js'
 
 /**
  * Wrap an async function and ensure it calls its callback on a later tick of

--- a/lib/internal/eachOfLimit.js
+++ b/lib/internal/eachOfLimit.js
@@ -1,7 +1,7 @@
 import once from './once.js'
 import iterator from './iterator.js'
 import onlyOnce from './onlyOnce.js'
-import {isAsyncGenerator, isAsyncIterable} from './wrapAsync.js'
+import { isAsyncGenerator, isAsyncIterable } from './isAsync.js'
 import asyncEachOfLimit from './asyncEachOfLimit.js'
 import breakLoop from './breakLoop.js'
 

--- a/lib/internal/isAsync.js
+++ b/lib/internal/isAsync.js
@@ -1,0 +1,13 @@
+function isAsync(fn) {
+    return fn[Symbol.toStringTag] === 'AsyncFunction';
+}
+
+function isAsyncGenerator(fn) {
+    return fn[Symbol.toStringTag] === 'AsyncGenerator';
+}
+
+function isAsyncIterable(obj) {
+    return typeof obj[Symbol.asyncIterator] === 'function';
+}
+
+export { isAsync, isAsyncGenerator, isAsyncIterable };

--- a/lib/internal/wrapAsync.js
+++ b/lib/internal/wrapAsync.js
@@ -1,16 +1,5 @@
 import asyncify from '../asyncify.js'
-
-function isAsync(fn) {
-    return fn[Symbol.toStringTag] === 'AsyncFunction';
-}
-
-function isAsyncGenerator(fn) {
-    return fn[Symbol.toStringTag] === 'AsyncGenerator';
-}
-
-function isAsyncIterable(obj) {
-    return typeof obj[Symbol.asyncIterator] === 'function';
-}
+import { isAsync } from './isAsync.js'
 
 function wrapAsync(asyncFn) {
     if (typeof asyncFn !== 'function') throw new Error('expected a function')
@@ -18,5 +7,3 @@ function wrapAsync(asyncFn) {
 }
 
 export default wrapAsync;
-
-export { isAsync, isAsyncGenerator, isAsyncIterable };

--- a/lib/retryable.js
+++ b/lib/retryable.js
@@ -1,6 +1,7 @@
 import retry from './retry.js'
 import initialParams from './internal/initialParams.js'
-import {default as wrapAsync, isAsync} from './internal/wrapAsync.js'
+import wrapAsync from './internal/wrapAsync.js'
+import { isAsync } from './internal/isAsync.js'
 import { promiseCallback, PROMISE_SYMBOL } from './internal/promiseCallback.js'
 
 /**


### PR DESCRIPTION
**./lib/asyncify.js**:
```js
import { isAsync } from './internal/wrapAsync.js'
```

**./lib/internal/wrapAsync.js**:
```js
import asyncify from '../asyncify.js'
```
