### PR TITLE
always wrap function

### DIFF
--- a/lib/internal/withoutIndex.js
+++ b/lib/internal/withoutIndex.js
@@ -1,3 +1,10 @@
 export default function _withoutIndex(iteratee) {
-    return (value, index, callback) => iteratee(value, callback);
+    // return (value, index, callback) => iteratee(value, callback);
+    return (value, index, callback) => {
+        const result = iteratee(value, callback);
+        if (result && typeof result.then === 'function') {
+            return result.then(callback)
+        }
+        return result;
+    }
 }

--- a/lib/internal/withoutIndex.js
+++ b/lib/internal/withoutIndex.js
@@ -1,10 +1,3 @@
 export default function _withoutIndex(iteratee) {
-    // return (value, index, callback) => iteratee(value, callback);
-    return (value, index, callback) => {
-        const result = iteratee(value, callback);
-        if (result && typeof result.then === 'function') {
-            return result.then(callback)
-        }
-        return result;
-    }
+    return (value, index, callback) => iteratee(value, callback);
 }

--- a/lib/internal/wrapAsync.js
+++ b/lib/internal/wrapAsync.js
@@ -1,4 +1,5 @@
 import asyncify from '../asyncify.js'
+import onlyOnce from './onlyOnce'
 
 function isAsync(fn) {
     return fn[Symbol.toStringTag] === 'AsyncFunction';
@@ -13,8 +14,19 @@ function isAsyncIterable(obj) {
 }
 
 function wrapAsync(asyncFn) {
+    function wrapPromise(fn) {
+        return function (...args) {
+            const cb = onlyOnce(args[args.length - 1])
+            args[args.length - 1] = cb
+            const result = fn.apply(this, args)
+            if (result && typeof result.then === 'function') {
+                return result.then(cb).catch(cb)
+            }
+            return result
+        }
+    }
     if (typeof asyncFn !== 'function') throw new Error('expected a function')
-    return asyncify(asyncFn)
+    return isAsync(asyncFn) ? asyncify(asyncFn) : wrapPromise(asyncFn);
 }
 
 export default wrapAsync;


### PR DESCRIPTION
Consider this:
```js
const asy = require('../dist/async')

const arr = [1, 2, 3]
const sleep = ms => new Promise(res => setTimeout(res, ms))
const fn = v => {
  console.log({v})
  return sleep(v)
}
asy.eachLimit(arr, 2, fn).then(() => {
  console.log('done')
}).catch(e => console.error('err:', e))
```
will print
```js
{ v: 1 }
{ v: 2 }
```
and `eachLimit` will never resolve or reject.

This can be fixed by manually add `async` keyword like
```js
const fn = async v => {
```
because this module uses `Symbol.toStringTag` to determin if a function is an async function.

However `fn` can be an async function even if it doesn't have an `async` keyword, because it can return a Promise.

So my fix is to wrap all `iteratee` function no matter it has an `async` keyword or not.

By doing so, `eachLimit` will be resolved:
```
{ v: 1 }
{ v: 2 }
{ v: 3 }
done
```

But I'm not sure if this change will effect other functions, so be careful if you are gonna merge...😅