### PR TITLE
Update changelog for v3.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v3.2.5
+- Ensure `Error` objects such as `AggregateError` are propagated without modification (#1920)
+
 # v3.2.4
 - Fix a bug in `priorityQueue` where it didn't wait for the result. (#1725)
 - Fix a bug where `unshiftAsync` was included in `priorityQueue`. (#1790)


### PR DESCRIPTION
Seems to have been forgotten for the 3.2.5 release. Keeping the changelog updated is very useful to quickly review what has changed so we don't need to dig around in commit logs.