### PR TITLE
Fix ReDoS

### DIFF
--- a/lib/autoInject.js
+++ b/lib/autoInject.js
@@ -3,7 +3,7 @@ import wrapAsync from './internal/wrapAsync.js'
 import { isAsync } from './internal/wrapAsync.js'
 
 var FN_ARGS = /^(?:async\s+)?(?:function)?\s*\w*\s*\(\s*([^)]+)\s*\)(?:\s*{)/;
-var ARROW_FN_ARGS = /^(?:async\s+)?\(?\s*([^)=]+)\s*\)?(?:\s*=>)/;
+var ARROW_FN_ARGS = /^(?:async\s+)?\s*\(?\s*([^)=]*)\s*\)?(?:\s*=>)/;
 var FN_ARG_SPLIT = /,/;
 var FN_ARG = /(=.+)?(\s*)$/;
 

--- a/lib/autoInject.js
+++ b/lib/autoInject.js
@@ -2,8 +2,8 @@ import auto from './auto.js'
 import wrapAsync from './internal/wrapAsync.js'
 import { isAsync } from './internal/wrapAsync.js'
 
-var FN_ARGS = /^(?:async\s+)?(?:function)?\s*\w*\s*\(\s*([^)]+)\s*\)(?:\s*{)/;
-var ARROW_FN_ARGS = /^(?:async\s+)?\s*\(?\s*([^)=]*)\s*\)?(?:\s*=>)/;
+var FN_ARGS = /^(?:async\s)?(?:function)?\s*(?:\w+\s*)?\(([^)]+)\)(?:\s*{)/;
+var ARROW_FN_ARGS = /^(?:async\s)?\s*(?:\(\s*)?((?:[^)=\s]\s*)*)(?:\)\s*)?=>/;
 var FN_ARG_SPLIT = /,/;
 var FN_ARG = /(=.+)?(\s*)$/;
 


### PR DESCRIPTION
This fixes the ReDoS issue that was reported in #1975.

I couldn't find a way to fix the ReDoS without making minor changes to the behavior of the regex, so I've split this PR into two commits to show what I've done. The first commit simplifies the regex, but in a way that will make it match a superset of the strings that it matched before. The second commit fixes the ReDoS (in both regexes) without changing their behavior.